### PR TITLE
Fixed null DDProperties reference in DimData

### DIFF
--- a/StevenDimDoors/mod_pocketDim/DimData.java
+++ b/StevenDimDoors/mod_pocketDim/DimData.java
@@ -33,8 +33,6 @@ public class DimData implements Serializable
 	
 	static final long serialVersionUID = 454342L;
 	
-	private static DDProperties properties = null;
-	
 	public DimData(int dimID, boolean isPocket, int depth, LinkData exitLinkData)
 	{
 		this.dimID=dimID;
@@ -42,9 +40,6 @@ public class DimData implements Serializable
 		this.isPocket=isPocket;
 		
 		this.exitDimLink= exitLinkData;
-
-		if (properties == null)
-			properties = DDProperties.instance();
 	}
 	
 	public DimData(int dimID, boolean isPocket, int depth, int exitLinkDimID, int exitX, int exitY, int exitZ)
@@ -59,6 +54,7 @@ public class DimData implements Serializable
 		int i=-range;
 		int j=-range;
 		int k=-range;
+		DDProperties properties = DDProperties.instance();
 		
 		while (i<range)
 		{
@@ -66,7 +62,7 @@ public class DimData implements Serializable
 			{
 				while (k<range)
 				{
-					if(world.getBlockId(x+i, y+j, z+k)==properties.RiftBlockID&&MathHelper.abs(i)+MathHelper.abs(j)+MathHelper.abs(k)<distance)
+					if (world.getBlockId(x+i, y+j, z+k) == properties.RiftBlockID && MathHelper.abs(i)+MathHelper.abs(j)+MathHelper.abs(k)<distance)
 					{
 						if(MathHelper.abs(i)+MathHelper.abs(j)+MathHelper.abs(k)!=0)
 						{
@@ -98,6 +94,7 @@ public class DimData implements Serializable
 		int i=-range;
 		int j=-range;
 		int k=-range;
+		DDProperties properties = DDProperties.instance();
 		
 		while (i<range)
 		{
@@ -167,44 +164,24 @@ public class DimData implements Serializable
 	
 	public LinkData addLinkToDim( int destinationDimID, int locationXCoord, int locationYCoord, int locationZCoord, int destinationXCoord, int destinationYCoord, int destinationZCoord, int linkOrientation)
 	{
-		
-		
-	
-		
 		LinkData linkData= new LinkData(this.dimID, destinationDimID, locationXCoord, locationYCoord, locationZCoord, destinationXCoord, destinationYCoord,destinationZCoord,this.isPocket,linkOrientation);
 		
-		
-		
 		return this.addLinkToDim(linkData);
-		
-		
-		
-		
-		
-		
 	}
 	
 	public boolean isLimbo()
 	{
-		if(this.dimID==properties.LimboDimensionID)
-		{
-			return true;
-			
-		}
-		else
-		{
-			return false;
-		}
+		return (this.dimID == DDProperties.instance().LimboDimensionID);
 	}
+	
 	public void removeLinkAtCoords(LinkData link)
 	{
 		this.removeLinkAtCoords(link.locDimID, link.locXCoord, link.locYCoord, link.locZCoord);
 	}
+	
 	public void removeLinkAtCoords(int locationID, int locationXCoord, int locationYCoord, int locationZCoord)
 	{
-		
-		
-		if(this.linksInThisDim.containsKey(locationZCoord))
+		if (this.linksInThisDim.containsKey(locationZCoord))
 		{
 			this.dimY=this.linksInThisDim.get(locationZCoord);
 			


### PR DESCRIPTION
Fixed null DDProperties reference in DimData. Changed the code so that
it requests an instance in each of its functions instead of relying on
loading a reference when it's first instantiated. I'm not sure how the
null references are slipping through, that shouldn't be possible.
