### PR TITLE
Minor Config Improvements and Overhauled Loot Generation

### DIFF
--- a/StevenDimDoors/mod_pocketDim/DDLoot.java
+++ b/StevenDimDoors/mod_pocketDim/DDLoot.java
@@ -1,0 +1,143 @@
+package StevenDimDoors.mod_pocketDim;
+
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.Random;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.WeightedRandomChestContent;
+import net.minecraftforge.common.ChestGenHooks;
+
+/*
+ * Registers a category of loot chests for Dimensional Doors in Forge.
+ */
+public class DDLoot {
+	
+	//These are the categories of loot to be merged into our chests
+	static final String[] chestSources = new String[] {
+			ChestGenHooks.MINESHAFT_CORRIDOR, 
+		    ChestGenHooks.PYRAMID_DESERT_CHEST,
+		    ChestGenHooks.PYRAMID_JUNGLE_CHEST,
+		    ChestGenHooks.STRONGHOLD_CORRIDOR,
+		    ChestGenHooks.STRONGHOLD_CROSSING,
+		    ChestGenHooks.VILLAGE_BLACKSMITH,
+		    ChestGenHooks.DUNGEON_CHEST
+		};
+	
+	public static final String DIMENSIONAL_DUNGEON_CHEST = "dimensionalDungeonChest";
+	public static ChestGenHooks DungeonChestInfo = null;
+	private static final int CHEST_SIZE = 8;
+	
+	private static final int COMMON_LOOT_WEIGHT = 10; //As common as iron ingots
+	private static final int UNCOMMON_LOOT_WEIGHT = 5; //As common as iron armor loot
+	private static final int RARE_LOOT_WEIGHT = 3; //As common as diamonds
+	private static final int DUNGEON_CHEST_WEIGHT_INFLATION = 10; // (weight of iron ingots in dungeon) / (weight of iron ingots in other chests)
+	
+	public static void registerInfo()
+	{
+		DDProperties properties = DDProperties.instance();
+		
+		//Register the dimensional dungeon chest with ChestGenHooks. This isn't necessary, but allows
+		//other mods to add their own loot to our chests if they know our loot category, without having
+		//to interface with our code.
+		DungeonChestInfo = ChestGenHooks.getInfo(DIMENSIONAL_DUNGEON_CHEST);
+		DungeonChestInfo.setMin(CHEST_SIZE);
+		DungeonChestInfo.setMax(CHEST_SIZE);
+
+		//Merge the item lists from source chests
+		//This means chests will include future loot as Minecraft updates! ^_^
+		ArrayList<WeightedRandomChestContent> items = mergeCategories(chestSources);
+		
+		//Add any enabled DD loot to the list of items
+		addContent(properties.FabricOfRealityLootEnabled, items, properties.FabricBlockID, 8, 32, COMMON_LOOT_WEIGHT);
+
+		addContent(properties.DimensionalDoorLootEnabled, items, properties.DimensionalDoorItemID, UNCOMMON_LOOT_WEIGHT);
+		addContent(properties.WarpDoorLootEnabled, items, properties.WarpDoorItemID, UNCOMMON_LOOT_WEIGHT);
+		addContent(properties.TransTrapdoorLootEnabled, items, properties.TransTrapdoorID, UNCOMMON_LOOT_WEIGHT);
+		addContent(properties.RiftSignatureLootEnabled, items, properties.RiftSignatureItemID, UNCOMMON_LOOT_WEIGHT);
+		addContent(properties.StableFabricLootEnabled, items, properties.StableFabricItemID, UNCOMMON_LOOT_WEIGHT);
+		addContent(properties.RiftRemoverLootEnabled, items, properties.RiftRemoverItemID, UNCOMMON_LOOT_WEIGHT);
+
+		addContent(properties.UnstableDoorLootEnabled, items, properties.UnstableDoorItemID, RARE_LOOT_WEIGHT);
+		addContent(properties.StabilizedRiftSignatureLootEnabled, items, properties.StabilizedRiftSignatureItemID, RARE_LOOT_WEIGHT);
+		addContent(properties.RiftBladeLootEnabled, items, properties.RiftBladeItemID, RARE_LOOT_WEIGHT);
+
+		//Add all the items to our dungeon chest
+		addItemsToContainer(DungeonChestInfo, items);
+	}
+	
+	private static ArrayList<WeightedRandomChestContent> mergeCategories(String[] categories)
+	{
+		//Retrieve the items of each container category and merge the lists together. If two matching items
+		//are found, choose the item with the minimum weight. Special checks are included for DUNGEON_CHEST
+		//because the items in that category have strange weights that are incompatible with all other
+		//chest categories.
+		
+		//This function has a flaw. It treats items with the same item ID but different damage values as
+		//the same item. For instance, it cannot distinguish between different types of wood. That shouldn't
+		//matter for most chest loot, though. This could be fixed if we cared enough.
+		Random random = new Random();
+		Hashtable<Integer, WeightedRandomChestContent> container = new Hashtable<Integer, WeightedRandomChestContent>();
+		
+		for (String category : categories)
+		{
+			WeightedRandomChestContent[] items = ChestGenHooks.getItems(category, random);
+			for (WeightedRandomChestContent item : items)
+			{
+				int id = item.theItemId.itemID;
+
+				//Correct the weights of Vanilla dungeon chests (DUNGEON_CHEST)
+				//Comparing by String references is valid here since they should match!
+				if (category == ChestGenHooks.DUNGEON_CHEST)
+				{
+					//It's okay to modify the weights directly. These are copies of instances,
+					//not direct references. It won't affect Vanilla chests.
+					item.itemWeight /= DUNGEON_CHEST_WEIGHT_INFLATION;
+					if (item.itemWeight == 0)
+						item.itemWeight = 1;
+				}				
+				if (!container.containsKey(id))
+				{
+					//This item has not been seen before. Simply add it to the container.
+					container.put(id, item);
+				}
+				else
+				{
+					//This item conflicts with an existing entry. Replace that entry
+					//if our current item has a lower weight.
+					WeightedRandomChestContent other = container.get(id);
+					if (item.itemWeight < other.itemWeight)
+					{
+						container.put(id, item);
+					}
+				}
+			}
+		}
+		
+		//Return merged list
+		return new ArrayList<WeightedRandomChestContent>( container.values() );
+	}
+	
+	private static void addContent(boolean include, ArrayList<WeightedRandomChestContent> items,
+			int itemID, int weight)
+	{
+		if (include)
+			items.add(new WeightedRandomChestContent(itemID, 0, 1, 1, weight));
+	}
+	
+	private static void addContent(boolean include, ArrayList<WeightedRandomChestContent> items,
+			int itemID, int minAmount, int maxAmount, int weight)
+	{
+		if (include)
+			items.add(new WeightedRandomChestContent(itemID, 0, minAmount, maxAmount, weight));
+	}
+	
+	private static void addItemsToContainer(ChestGenHooks container, ArrayList<WeightedRandomChestContent> items)
+	{
+		for (WeightedRandomChestContent item : items)
+		{
+			container.addItem(item);
+		}
+	}
+}

--- a/StevenDimDoors/mod_pocketDim/DDProperties.java
+++ b/StevenDimDoors/mod_pocketDim/DDProperties.java
@@ -63,6 +63,21 @@ public class DDProperties
 	public final boolean CraftingTransTrapdoorAllowed;
 	public final boolean CraftingStabilizedRiftSignatureAllowed;
 	public final boolean CraftingStableFabricAllowed;
+	
+	/**
+	 * Loot Flags
+	 */
+	
+	public final boolean DimensionalDoorLootEnabled;
+	public final boolean WarpDoorLootEnabled;
+	public final boolean UnstableDoorLootEnabled;
+	public final boolean TransTrapdoorLootEnabled;
+	public final boolean RiftSignatureLootEnabled;
+	public final boolean RiftRemovedLootEnabled;
+	public final boolean StabilizedRiftSignatureLootEnabled;
+	public final boolean RiftBladeLootEnabled;
+	public final boolean StableFabricLootEnabled;
+	public final boolean FabricOfRealityLootEnabled;
 
 	/**
 	 * Other Flags
@@ -107,15 +122,26 @@ public class DDProperties
 		Configuration config = new Configuration(configFile);
 		config.load();
 
-		CraftingDimensionaDoorAllowed = config.get(CATEGORY_CRAFTING, "Allow Crafting Dimesional Door", true).getBoolean(true);
+		CraftingDimensionaDoorAllowed = config.get(CATEGORY_CRAFTING, "Allow Crafting Dimensional Door", true).getBoolean(true);
 		CraftingWarpDoorAllowed = config.get(CATEGORY_CRAFTING, "Allow Crafting Warp Door", true).getBoolean(true);
-		CraftingUnstableDoorAllowed = config.get(CATEGORY_CRAFTING, "Allow Crating Unstable Door", true).getBoolean(true);
+		CraftingUnstableDoorAllowed = config.get(CATEGORY_CRAFTING, "Allow Crafting Unstable Door", true).getBoolean(true);
 		CraftingTransTrapdoorAllowed = config.get(CATEGORY_CRAFTING, "Allow Crafting Transdimensional Trapdoor", true).getBoolean(true);
 		CraftingRiftSignatureAllowed = config.get(CATEGORY_CRAFTING, "Allow Crafting Rift Signature", true).getBoolean(true);
 		CraftingRiftRemoverAllowed = config.get(CATEGORY_CRAFTING, "Allow Crafting Rift Remover", true).getBoolean(true);
 		CraftingStabilizedRiftSignatureAllowed = config.get(CATEGORY_CRAFTING, "Allow Crafting Stabilized Rift Signature", true).getBoolean(true);
 		CraftingRiftBladeAllowed = config.get(CATEGORY_CRAFTING, "Allow Crafting Rift Blade", true).getBoolean(true);
 		CraftingStableFabricAllowed = config.get(CATEGORY_CRAFTING, "Allow Crafting Stable Fabric", true).getBoolean(true);
+		
+		DimensionalDoorLootEnabled = config.get(Configuration.CATEGORY_GENERAL, "Enable Dimensional Door Loot", true).getBoolean(true);
+		WarpDoorLootEnabled = config.get(Configuration.CATEGORY_GENERAL, "Enable Warp Door Loot", false).getBoolean(false);
+		UnstableDoorLootEnabled = config.get(Configuration.CATEGORY_GENERAL, "Enable Unstable Door Loot", false).getBoolean(false);
+		TransTrapdoorLootEnabled = config.get(Configuration.CATEGORY_GENERAL, "Enable Transdimensional Trapdoor Loot", false).getBoolean(false);
+		RiftSignatureLootEnabled = config.get(Configuration.CATEGORY_GENERAL, "Enable Rift Signature Loot", true).getBoolean(true);
+		RiftRemovedLootEnabled = config.get(Configuration.CATEGORY_GENERAL, "Enable Rift Remover Loot", true).getBoolean(true);
+		StabilizedRiftSignatureLootEnabled = config.get(Configuration.CATEGORY_GENERAL, "Enable Stabilized Rift Signature Loot", false).getBoolean(false);
+		RiftBladeLootEnabled = config.get(Configuration.CATEGORY_GENERAL, "Enable Rift Blade Loot", true).getBoolean(true);
+		StableFabricLootEnabled = config.get(Configuration.CATEGORY_GENERAL, "Enable Stable Fabric Loot", false).getBoolean(false);
+		FabricOfRealityLootEnabled = config.get(Configuration.CATEGORY_GENERAL, "Enable Fabric of Reality Loot", true).getBoolean(true);
 
 		RiftGriefingEnabled = config.get(Configuration.CATEGORY_GENERAL, "Enable Rift Griefing", true,
 				"Sets whether rifts destroy blocks around them or not").getBoolean(true);

--- a/StevenDimDoors/mod_pocketDim/DDProperties.java
+++ b/StevenDimDoors/mod_pocketDim/DDProperties.java
@@ -73,7 +73,7 @@ public class DDProperties
 	public final boolean UnstableDoorLootEnabled;
 	public final boolean TransTrapdoorLootEnabled;
 	public final boolean RiftSignatureLootEnabled;
-	public final boolean RiftRemovedLootEnabled;
+	public final boolean RiftRemoverLootEnabled;
 	public final boolean StabilizedRiftSignatureLootEnabled;
 	public final boolean RiftBladeLootEnabled;
 	public final boolean StableFabricLootEnabled;
@@ -137,7 +137,7 @@ public class DDProperties
 		UnstableDoorLootEnabled = config.get(Configuration.CATEGORY_GENERAL, "Enable Unstable Door Loot", false).getBoolean(false);
 		TransTrapdoorLootEnabled = config.get(Configuration.CATEGORY_GENERAL, "Enable Transdimensional Trapdoor Loot", false).getBoolean(false);
 		RiftSignatureLootEnabled = config.get(Configuration.CATEGORY_GENERAL, "Enable Rift Signature Loot", true).getBoolean(true);
-		RiftRemovedLootEnabled = config.get(Configuration.CATEGORY_GENERAL, "Enable Rift Remover Loot", true).getBoolean(true);
+		RiftRemoverLootEnabled = config.get(Configuration.CATEGORY_GENERAL, "Enable Rift Remover Loot", true).getBoolean(true);
 		StabilizedRiftSignatureLootEnabled = config.get(Configuration.CATEGORY_GENERAL, "Enable Stabilized Rift Signature Loot", false).getBoolean(false);
 		RiftBladeLootEnabled = config.get(Configuration.CATEGORY_GENERAL, "Enable Rift Blade Loot", true).getBoolean(true);
 		StableFabricLootEnabled = config.get(Configuration.CATEGORY_GENERAL, "Enable Stable Fabric Loot", false).getBoolean(false);

--- a/StevenDimDoors/mod_pocketDim/SchematicLoader.java
+++ b/StevenDimDoors/mod_pocketDim/SchematicLoader.java
@@ -967,36 +967,12 @@ public class SchematicLoader
 
 							
 		                    	//	System.out.println("found container");
-		                    		Random rand= new Random();
 		                    		if(world.getBlockTileEntity(i+xCooe, j+yCooe, k+zCooe) instanceof TileEntityChest)
 		                    		{
 		                    			TileEntityChest chest = (TileEntityChest) world.getBlockTileEntity(i+xCooe, j+yCooe, k+zCooe);
 
-		                    		   ChestGenHooks info = ChestGenHooks.getInfo(ChestGenHooks.DUNGEON_CHEST);
-		                    		   if(rand.nextBoolean())
-		                    		   {
-		                    			   chest.setInventorySlotContents(rand.nextInt(27), new ItemStack(mod_pocketDim.itemDimDoor, 1));
-		                    		   }
-		                    		   if(rand.nextBoolean())
-		                    		   {
-		                    			   chest.setInventorySlotContents(rand.nextInt(27), new ItemStack(mod_pocketDim.itemLinkSignature, 1));
-		                    		   }
-		                    		   if(rand.nextBoolean())
-		                    		   {
-		                    			   chest.setInventorySlotContents(rand.nextInt(27), new ItemStack(mod_pocketDim.itemRiftRemover, 1));
-		                    		   }
-		                    		   if(rand.nextBoolean())
-		                    		   {
-		                    			   chest.setInventorySlotContents(rand.nextInt(27), new ItemStack(mod_pocketDim.itemRiftBlade, 1));
-		                    		   }
-		                    		   if(rand.nextBoolean())
-		                    		   {
-		                    			   chest.setInventorySlotContents(rand.nextInt(27), new ItemStack(mod_pocketDim.blockDimWall, rand.nextInt(20)+5));
-		                    		   }
-	                                    WeightedRandomChestContent.generateChestContents(rand, info.getItems(rand),(TileEntityChest)world.getBlockTileEntity(i+xCooe, j+yCooe, k+zCooe)  , info.getCount(rand));
-
-
-
+		                    			ChestGenHooks info = ChestGenHooks.getInfo(DDLoot.DIMENSIONAL_DUNGEON_CHEST);
+		                    			WeightedRandomChestContent.generateChestContents(rand, info.getItems(rand), (TileEntityChest)world.getBlockTileEntity(i+xCooe, j+yCooe, k+zCooe), info.getCount(rand));
 		                    		}
 		                    		if(world.getBlockTileEntity(i+xCooe, j+yCooe, k+zCooe) instanceof TileEntityDispenser)
 		                    		{
@@ -1004,8 +980,6 @@ public class SchematicLoader
 		                    			dispenser.addItem(new ItemStack(Item.arrow, 64));
 
 		                    		}
-
-
 						}
 					}
 				}

--- a/StevenDimDoors/mod_pocketDim/blocks/BlockDimWallPerm.java
+++ b/StevenDimDoors/mod_pocketDim/blocks/BlockDimWallPerm.java
@@ -118,7 +118,7 @@ public class BlockDimWallPerm extends Block
 
 
 				{
-
+					EntityPlayer.class.cast(par5Entity).setPositionAndUpdate( x, y, z );
 				}
 
 

--- a/StevenDimDoors/mod_pocketDim/mod_pocketDim.java
+++ b/StevenDimDoors/mod_pocketDim/mod_pocketDim.java
@@ -395,6 +395,9 @@ public class mod_pocketDim
 
 		proxy.loadTextures();
 		proxy.registerRenderers();
+		
+		//Register loot chests
+		DDLoot.registerInfo();
 	}
 
 


### PR DESCRIPTION
Dimensional dungeon loot chests are now registered with Forge. Other mods can tap into our chests and our own generation is cleaner. The list of items in our chests is generated in DDLoot.

Resolved:
Issue #14 - No way to control if DD items appear in chests
