### PR TITLE
Loot Generation Improvements

### DIFF
--- a/StevenDimDoors/mod_pocketDim/DDLoot.java
+++ b/StevenDimDoors/mod_pocketDim/DDLoot.java
@@ -4,8 +4,6 @@ import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.Random;
 
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.WeightedRandomChestContent;
 import net.minecraftforge.common.ChestGenHooks;
 
@@ -27,7 +25,7 @@ public class DDLoot {
 	
 	public static final String DIMENSIONAL_DUNGEON_CHEST = "dimensionalDungeonChest";
 	public static ChestGenHooks DungeonChestInfo = null;
-	private static final int CHEST_SIZE = 8;
+	private static final int CHEST_SIZE = 5;
 	
 	private static final int COMMON_LOOT_WEIGHT = 10; //As common as iron ingots
 	private static final int UNCOMMON_LOOT_WEIGHT = 5; //As common as iron armor loot
@@ -50,18 +48,18 @@ public class DDLoot {
 		ArrayList<WeightedRandomChestContent> items = mergeCategories(chestSources);
 		
 		//Add any enabled DD loot to the list of items
-		addContent(properties.FabricOfRealityLootEnabled, items, properties.FabricBlockID, 8, 32, COMMON_LOOT_WEIGHT);
+		addContent(properties.FabricOfRealityLootEnabled, items, mod_pocketDim.blockDimWall.blockID, 8, 32, COMMON_LOOT_WEIGHT);
 
-		addContent(properties.DimensionalDoorLootEnabled, items, properties.DimensionalDoorItemID, UNCOMMON_LOOT_WEIGHT);
-		addContent(properties.WarpDoorLootEnabled, items, properties.WarpDoorItemID, UNCOMMON_LOOT_WEIGHT);
-		addContent(properties.TransTrapdoorLootEnabled, items, properties.TransTrapdoorID, UNCOMMON_LOOT_WEIGHT);
-		addContent(properties.RiftSignatureLootEnabled, items, properties.RiftSignatureItemID, UNCOMMON_LOOT_WEIGHT);
-		addContent(properties.StableFabricLootEnabled, items, properties.StableFabricItemID, UNCOMMON_LOOT_WEIGHT);
-		addContent(properties.RiftRemoverLootEnabled, items, properties.RiftRemoverItemID, UNCOMMON_LOOT_WEIGHT);
+		addContent(properties.DimensionalDoorLootEnabled, items, mod_pocketDim.itemDimDoor.itemID, UNCOMMON_LOOT_WEIGHT);
+		addContent(properties.WarpDoorLootEnabled, items, mod_pocketDim.itemExitDoor.itemID, UNCOMMON_LOOT_WEIGHT);
+		addContent(properties.TransTrapdoorLootEnabled, items, mod_pocketDim.dimHatch.blockID, UNCOMMON_LOOT_WEIGHT);
+		addContent(properties.RiftSignatureLootEnabled, items, mod_pocketDim.itemLinkSignature.itemID, UNCOMMON_LOOT_WEIGHT);
+		addContent(properties.StableFabricLootEnabled, items, mod_pocketDim.itemStableFabric.itemID, UNCOMMON_LOOT_WEIGHT);
+		addContent(properties.RiftRemoverLootEnabled, items, mod_pocketDim.itemRiftRemover.itemID, UNCOMMON_LOOT_WEIGHT);
 
-		addContent(properties.UnstableDoorLootEnabled, items, properties.UnstableDoorItemID, RARE_LOOT_WEIGHT);
-		addContent(properties.StabilizedRiftSignatureLootEnabled, items, properties.StabilizedRiftSignatureItemID, RARE_LOOT_WEIGHT);
-		addContent(properties.RiftBladeLootEnabled, items, properties.RiftBladeItemID, RARE_LOOT_WEIGHT);
+		addContent(properties.UnstableDoorLootEnabled, items, mod_pocketDim.itemChaosDoor.itemID, RARE_LOOT_WEIGHT);
+		addContent(properties.StabilizedRiftSignatureLootEnabled, items, mod_pocketDim.itemStabilizedLinkSignature.itemID, RARE_LOOT_WEIGHT);
+		addContent(properties.RiftBladeLootEnabled, items, mod_pocketDim.itemRiftBlade.itemID, RARE_LOOT_WEIGHT);
 
 		//Add all the items to our dungeon chest
 		addItemsToContainer(DungeonChestInfo, items);
@@ -135,9 +133,13 @@ public class DDLoot {
 	
 	private static void addItemsToContainer(ChestGenHooks container, ArrayList<WeightedRandomChestContent> items)
 	{
+		//System.out.println("Preparing Chest Stuff");
+		
 		for (WeightedRandomChestContent item : items)
 		{
 			container.addItem(item);
+			//Uncomment this code to print out loot and weight pairs
+			//System.out.println(item.theItemId.getDisplayName() + "\t" + item.itemWeight);
 		}
 	}
 }

--- a/StevenDimDoors/mod_pocketDim/DDProperties.java
+++ b/StevenDimDoors/mod_pocketDim/DDProperties.java
@@ -112,6 +112,7 @@ public class DDProperties
 	private final String CATEGORY_DIMENSION = "dimension";
 	private final String CATEGORY_PROVIDER = "provider";
 	private final String CATEGORY_BIOME = "biome";
+	private final String CATEGORY_LOOT = "loot";	
 	
 	private DDProperties(File configFile)
 	{
@@ -132,16 +133,16 @@ public class DDProperties
 		CraftingRiftBladeAllowed = config.get(CATEGORY_CRAFTING, "Allow Crafting Rift Blade", true).getBoolean(true);
 		CraftingStableFabricAllowed = config.get(CATEGORY_CRAFTING, "Allow Crafting Stable Fabric", true).getBoolean(true);
 		
-		DimensionalDoorLootEnabled = config.get(Configuration.CATEGORY_GENERAL, "Enable Dimensional Door Loot", true).getBoolean(true);
-		WarpDoorLootEnabled = config.get(Configuration.CATEGORY_GENERAL, "Enable Warp Door Loot", false).getBoolean(false);
-		UnstableDoorLootEnabled = config.get(Configuration.CATEGORY_GENERAL, "Enable Unstable Door Loot", false).getBoolean(false);
-		TransTrapdoorLootEnabled = config.get(Configuration.CATEGORY_GENERAL, "Enable Transdimensional Trapdoor Loot", false).getBoolean(false);
-		RiftSignatureLootEnabled = config.get(Configuration.CATEGORY_GENERAL, "Enable Rift Signature Loot", true).getBoolean(true);
-		RiftRemoverLootEnabled = config.get(Configuration.CATEGORY_GENERAL, "Enable Rift Remover Loot", true).getBoolean(true);
-		StabilizedRiftSignatureLootEnabled = config.get(Configuration.CATEGORY_GENERAL, "Enable Stabilized Rift Signature Loot", false).getBoolean(false);
-		RiftBladeLootEnabled = config.get(Configuration.CATEGORY_GENERAL, "Enable Rift Blade Loot", true).getBoolean(true);
-		StableFabricLootEnabled = config.get(Configuration.CATEGORY_GENERAL, "Enable Stable Fabric Loot", false).getBoolean(false);
-		FabricOfRealityLootEnabled = config.get(Configuration.CATEGORY_GENERAL, "Enable Fabric of Reality Loot", true).getBoolean(true);
+		DimensionalDoorLootEnabled = config.get(CATEGORY_LOOT, "Enable Dimensional Door Loot", true).getBoolean(true);
+		WarpDoorLootEnabled = config.get(CATEGORY_LOOT, "Enable Warp Door Loot", false).getBoolean(false);
+		UnstableDoorLootEnabled = config.get(CATEGORY_LOOT, "Enable Unstable Door Loot", false).getBoolean(false);
+		TransTrapdoorLootEnabled = config.get(CATEGORY_LOOT, "Enable Transdimensional Trapdoor Loot", false).getBoolean(false);
+		RiftSignatureLootEnabled = config.get(CATEGORY_LOOT, "Enable Rift Signature Loot", true).getBoolean(true);
+		RiftRemoverLootEnabled = config.get(CATEGORY_LOOT, "Enable Rift Remover Loot", true).getBoolean(true);
+		StabilizedRiftSignatureLootEnabled = config.get(CATEGORY_LOOT, "Enable Stabilized Rift Signature Loot", false).getBoolean(false);
+		RiftBladeLootEnabled = config.get(CATEGORY_LOOT, "Enable Rift Blade Loot", true).getBoolean(true);
+		StableFabricLootEnabled = config.get(CATEGORY_LOOT, "Enable Stable Fabric Loot", false).getBoolean(false);
+		FabricOfRealityLootEnabled = config.get(CATEGORY_LOOT, "Enable Fabric of Reality Loot", true).getBoolean(true);
 
 		RiftGriefingEnabled = config.get(Configuration.CATEGORY_GENERAL, "Enable Rift Griefing", true,
 				"Sets whether rifts destroy blocks around them or not").getBoolean(true);

--- a/StevenDimDoors/mod_pocketDim/mod_pocketDim.java
+++ b/StevenDimDoors/mod_pocketDim/mod_pocketDim.java
@@ -395,15 +395,14 @@ public class mod_pocketDim
 
 		proxy.loadTextures();
 		proxy.registerRenderers();
-		
-		//Register loot chests
-		DDLoot.registerInfo();
 	}
 
 
 	@PostInit
 	public void PostInit(FMLPostInitializationEvent event)
-	{
+	{	
+		//Register loot chests
+		DDLoot.registerInfo();
 	}
 
 	@ServerStopping


### PR DESCRIPTION
Changed DDLoot to use the correct item IDs when adding DD items to chests. Moved loot chest registration from init() to postInit() in the hopes that we'll be able to catch the loot of other mods that also hook into Vanilla chests.
