### PR TITLE
Added Name Filtering to CommandEndDungeonCreation

### DIFF
--- a/StevenDimDoors/mod_pocketDim/commands/CommandEndDungeonCreation.java
+++ b/StevenDimDoors/mod_pocketDim/commands/CommandEndDungeonCreation.java
@@ -1,17 +1,18 @@
 package StevenDimDoors.mod_pocketDim.commands;
 
-import StevenDimDoors.mod_pocketDim.DDProperties;
-import StevenDimDoors.mod_pocketDim.DungeonGenerator;
-import StevenDimDoors.mod_pocketDim.mod_pocketDim;
-import StevenDimDoors.mod_pocketDim.helpers.DungeonHelper;
-import StevenDimDoors.mod_pocketDim.helpers.dimHelper;
+import java.util.regex.Pattern;
+
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.entity.player.EntityPlayer;
+import StevenDimDoors.mod_pocketDim.DDProperties;
+import StevenDimDoors.mod_pocketDim.DungeonGenerator;
+import StevenDimDoors.mod_pocketDim.mod_pocketDim;
 
 public class CommandEndDungeonCreation extends CommandBase
 {
 	private static DDProperties properties = null;
+	private static Pattern nameFilter = Pattern.compile("[A-Za-z0-9_]+");
 	
 	public CommandEndDungeonCreation()
 	{
@@ -26,10 +27,8 @@ public class CommandEndDungeonCreation extends CommandBase
 
 	@Override
 	public void processCommand(ICommandSender var1, String[] var2) 
-
 	{
-		
-		EntityPlayer player =this.getCommandSenderAsPlayer(var1);
+		EntityPlayer player = this.getCommandSenderAsPlayer(var1);
 		
 		if(!mod_pocketDim.dungeonHelper.customDungeonStatus.containsKey(player.worldObj.provider.dimensionId))
 		{
@@ -59,15 +58,23 @@ public class CommandEndDungeonCreation extends CommandBase
 		}
 		else if(!player.worldObj.isRemote)
 		{
-			DungeonGenerator newDungeon = mod_pocketDim.dungeonHelper.exportDungeon(player.worldObj, x, y, z, properties.CustomSchematicDirectory + "/" + var2[0] + ".schematic");
-			player.sendChatToPlayer("created dungeon schematic in " + properties.CustomSchematicDirectory +"/"+var2[0]+".schematic");
-			mod_pocketDim.dungeonHelper.customDungeons.add(newDungeon);
-			
-			if(mod_pocketDim.dungeonHelper.customDungeonStatus.containsKey(player.worldObj.provider.dimensionId)&&!player.worldObj.isRemote)
+			//Check that the dungeon name is valid to prevent directory traversal and other forms of abuse
+			if (nameFilter.matcher(var2[0]).matches())
 			{
-			//	mod_pocketDim.dungeonHelper.customDungeonStatus.remove(player.worldObj.provider.dimensionId);
-			//	dimHelper.instance.teleportToPocket(player.worldObj, mod_pocketDim.dungeonHelper.customDungeonStatus.get(player.worldObj.provider.dimensionId), player);
-
+				DungeonGenerator newDungeon = mod_pocketDim.dungeonHelper.exportDungeon(player.worldObj, x, y, z, properties.CustomSchematicDirectory + "/" + var2[0] + ".schematic");
+				player.sendChatToPlayer("created dungeon schematic in " + properties.CustomSchematicDirectory +"/"+var2[0]+".schematic");
+				mod_pocketDim.dungeonHelper.customDungeons.add(newDungeon);
+				
+				if(mod_pocketDim.dungeonHelper.customDungeonStatus.containsKey(player.worldObj.provider.dimensionId)&&!player.worldObj.isRemote)
+				{
+				//	mod_pocketDim.dungeonHelper.customDungeonStatus.remove(player.worldObj.provider.dimensionId);
+				//	dimHelper.instance.teleportToPocket(player.worldObj, mod_pocketDim.dungeonHelper.customDungeonStatus.get(player.worldObj.provider.dimensionId), player);
+	
+				}
+			}
+			else
+			{
+				player.sendChatToPlayer("Invalid schematic name. Please use only letters, numbers, and underscores.");
 			}
 		}
 


### PR DESCRIPTION
Added a regex filter for bad schematic names in CommandEndDungeonCreation. Names can only be made of letters, numbers, and underscores now. This should prevent any nasty tricks people might try to affect the underlying file system.
