### PR TITLE
 Partially Fixed Rotation Bugs 

### DIFF
--- a/StevenDimDoors/mod_pocketDim/Point3D.java
+++ b/StevenDimDoors/mod_pocketDim/Point3D.java
@@ -1,58 +1,63 @@
 package StevenDimDoors.mod_pocketDim;
 
 import java.io.Serializable;
+
 public class Point3D implements Serializable {
- 
-    private  int x;
-    private  int y;
-    private  int z;
- 
-     public Point3D(int x, int y,int z) 
-     
-     
-     {
-        this.x = x;
-        this.y = y;
-        this.z = z;
-    }
- 
-    public int getX() 
-    {
-        return x;
-    }
- 
-    public int getY() 
-    {
-        return y;
-    }
-    
-    public int getZ() 
-    {
-        return z;
-    }
- 
-      public int setY(int y) 
-      {
-        return this.y=y;
-    }
-       public int setX(int x) 
-       {
-        return this. x=x;
-    }
-     public int setZ(int z) 
-     {
-        return this. z=z;
-    }
- public boolean equals(Object other) 
- {
-    boolean result = false;
-    if (other instanceof Point3D) 
-    {
-        Point3D that = (Point3D) other;
-        result = (this.getX() == that.getX() && this.getY() == that.getY()&& this.getY() == that.getZ());
-    }
-    return result;
-}
- 
- 
+
+	private  int x;
+	private  int y;
+	private  int z;
+
+	public Point3D(int x, int y,int z) 
+	{
+		this.x = x;
+		this.y = y;
+		this.z = z;
+	}
+
+	public int getX() 
+	{
+		return x;
+	}
+
+	public int getY() 
+	{
+		return y;
+	}
+
+	public int getZ() 
+	{
+		return z;
+	}
+
+	public int setY(int y) 
+	{
+		return this.y=y;
+	}
+	
+	public int setX(int x) 
+	{
+		return this. x=x;
+	}
+	
+	public int setZ(int z) 
+	{
+		return this. z=z;
+	}
+	
+	public Point3D clone()
+	{
+		return new Point3D(x, y, z);
+	}
+	
+	public boolean equals(Object other) 
+	{
+		boolean result = false;
+		if (other instanceof Point3D) 
+		{
+			Point3D that = (Point3D) other;
+			result = (this.getX() == that.getX() && this.getY() == that.getY()&& this.getY() == that.getZ());
+		}
+		return result;
+	}
 }


### PR DESCRIPTION
It turns out my earlier commits didn't completely fix things because certain implementation details were missing. I had assumed they were done. Also, some of the information I had regarding the default schematic orientation was wrong. This commit remedies most of those problems with a robust rotation implementation. However, I haven't added the code for linking Warp Doors yet, and there is a bug with tile entities getting reversed in East/West oriented rooms. Not sure why that's happening.
