### PR TITLE
Actually log the error in onTickInGame, instead of printing a not-very-descriptive message.

### DIFF
--- a/StevenDimDoors/mod_pocketDim/CommonTickHandler.java
+++ b/StevenDimDoors/mod_pocketDim/CommonTickHandler.java
@@ -106,7 +106,8 @@ public class CommonTickHandler implements ITickHandler
 		catch (Exception e)
 		{
 			tickCount++;
-			System.out.println("something on tick went wrong");
+			System.out.println("something on tick went wrong: " + e);
+			e.printStackTrace();
 		}
 		tickCount++;
 


### PR DESCRIPTION
Signed-off-by: Ross Allan rallanpcl@gmail.com
