### PR TITLE
Fixed NPE in RiftRegenerator

### DIFF
--- a/StevenDimDoors/mod_pocketDim/mod_pocketDim.java
+++ b/StevenDimDoors/mod_pocketDim/mod_pocketDim.java
@@ -186,7 +186,7 @@ public class mod_pocketDim
 		//MonolithSpawner should be initialized before any provider instances are created
 		//Register the other regular tick receivers as well
 		spawner = new MonolithSpawner(commonTickHandler, properties);
-		new RiftRegenerator(commonTickHandler); //No need to store the reference
+		new RiftRegenerator(commonTickHandler, properties); //No need to store the reference
 		LimboDecay decay = new LimboDecay(commonTickHandler, properties);
 
 		transientDoor = (new TransientDoor(properties.TransientDoorID, Material.iron)).setHardness(1.0F) .setUnlocalizedName("transientDoor");

--- a/StevenDimDoors/mod_pocketDim/ticking/RiftRegenerator.java
+++ b/StevenDimDoors/mod_pocketDim/ticking/RiftRegenerator.java
@@ -15,9 +15,10 @@ public class RiftRegenerator implements IRegularTickReceiver {
 
 	private DDProperties properties;
 	
-	public RiftRegenerator(IRegularTickSender sender)
+	public RiftRegenerator(IRegularTickSender sender, DDProperties properties)
 	{
 		sender.registerForTicking(this, RIFT_REGENERATION_INTERVAL, false);
+		this.properties = properties;
 	}
 	
 	@Override


### PR DESCRIPTION
Fixed a NullPointerException in RiftRegenerator. I had forgotten to
initialize the properties field for use in the class.
