### PR TITLE
Avoid testing LinkData that does not belong to the same dimension

### DIFF
--- a/StevenDimDoors/mod_pocketDim/EventHookContainer.java
+++ b/StevenDimDoors/mod_pocketDim/EventHookContainer.java
@@ -58,6 +58,10 @@ public class EventHookContainer
     			{    			
 	    			for (LinkData link:dimHelper.instance.getDimData(world.provider.dimensionId).getLinksInDim())
 	    			{
+	    				if (world.provider.dimensionId != link.locDimID)
+	    				{
+	    					continue;
+	    				}
 	    				if (!mod_pocketDim.blockRift.isBlockImmune(world, link.locXCoord, link.locYCoord, link.locZCoord))
 	    				{
 	        				dimHelper.getWorld(link.locDimID).setBlock(link.locXCoord, link.locYCoord, link.locZCoord, properties.RiftBlockID);


### PR DESCRIPTION
This is a quick hot-fix for not only the NPE spam, but also doors being eaten by rifts.

The problem in both cases is that the LinkData's dimID ("dimHelper.getWorld(link.locDimID)") and the current dimID ("mod_pocketDim.blockRift.isBlockImmune(world, link.locXCoord, link.locYCoord, link.locZCoord)") are mismatched, causing the checked block to by from another dimension, eating doors (not detected) and causing NPEs (the dimension of the LinkData has been unloaded, or similarly causing the LinkData pulled in the onBlockAdded method to be null)

This does not fix the actual problem of the mismatch, but should temporarily patch the issue until the mismatching of LinkData dimension IDs is resolved
