### PR TITLE
Improved Dungeon Loot and Selection

### DIFF
--- a/StevenDimDoors/mod_pocketDim/dungeon/FillContainersOperation.java
+++ b/StevenDimDoors/mod_pocketDim/dungeon/FillContainersOperation.java
@@ -10,9 +10,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityChest;
 import net.minecraft.tileentity.TileEntityDispenser;
-import net.minecraft.util.WeightedRandomChestContent;
 import net.minecraft.world.World;
-import net.minecraftforge.common.ChestGenHooks;
 import StevenDimDoors.mod_pocketDim.DDLoot;
 import StevenDimDoors.mod_pocketDim.schematic.WorldOperation;
 
@@ -42,8 +40,7 @@ public class FillContainersOperation extends WorldOperation
 				TileEntityChest chest = (TileEntityChest) tileEntity;
 				if (isInventoryEmpty(chest))
 				{
-					ChestGenHooks info = DDLoot.DungeonChestInfo;
-					WeightedRandomChestContent.generateChestContents(random, info.getItems(random), chest, info.getCount(random));
+					DDLoot.generateChestContents(DDLoot.DungeonChestInfo, chest, random);
 				}
 			}
 			

--- a/schematics/ruins/rules.txt
+++ b/schematics/ruins/rules.txt
@@ -22,14 +22,22 @@ Exit -> DeadEnd Exit
 
 DeadEnd -> DeadEnd Exit
 
-? ? ? ? ? ? ? ? -> Trap#20 SimpleHall#40 ComplexHall#10 Exit#20 DeadEnd#10
+? ? ? ? ? ? ? ? ? -> DeadEnd#10 Exit#11 SimpleHall#24 ComplexHall#16 Trap#23 Maze#11
 
-? ? ? ? -> Trap#18 SimpleHall#40 ComplexHall#10 Exit#18 DeadEnd#10 Hub#4
+? ? ? ? ? ? ? ? -> DeadEnd#9 Exit#10 SimpleHall#24 ComplexHall#16 Trap#23 Maze#11 Hub#6
 
-? ? ? -> ComplexHall Hub Trap SimpleHall Maze
+? ? ? ? ? ? ? -> DeadEnd#8 Exit#9 SimpleHall#25 ComplexHall#17 Trap#23 Maze#11 Hub#7
 
-? ?	-> ComplexHall Hub Trap SimpleHall Maze
+? ? ? ? ? ? -> DeadEnd#7 Exit#8 SimpleHall#26 ComplexHall#17 Trap#23 Maze#11 Hub#8
 
-? -> ComplexHall#40 Hub#30 Trap#10 SimpleHall#10 Maze#10
+? ? ? ? ? -> DeadEnd#6 Exit#6 SimpleHall#27 ComplexHall#18 Trap#23 Maze#11 Hub#9
 
--> ComplexHall#40 Hub#30 Trap#10 SimpleHall#10 Maze#10
+? ? ? ? -> DeadEnd#5 Exit#5 SimpleHall#28 ComplexHall#18 Trap#23 Maze#11 Hub#10
+
+? ? ? -> DeadEnd#3 Exit#3 SimpleHall#29 ComplexHall#19 Trap#23 Maze#11 Hub#11
+
+? ? -> SimpleHall#9 ComplexHall#8 Trap#17 Maze#23 Hub#44
+
+? -> SimpleHall#9 ComplexHall#8 Trap#17 Maze#23 Hub#44
+
+-> SimpleHall#2 ComplexHall#54 Trap#2 Maze#2 Hub#41


### PR DESCRIPTION
DDLoot: Implemented a custom version of MC's generateChestContents() for
our own chests. It avoids two notable bugs that affect MC's version.

FillContainersOperation: Changed code to use
DDLoot.generateChestContents()

SchematicLoader: Fixed a bug in the way we calculated a seed for
selecting our dungeons that would cause certain seeds to dominate all
the others. Under certain circumstances, the function would only return
-1. That would make our dungeon selection severely biased. That was
resolved and the code was specifically tuned for seeding Java's Random
even for doors with nearly identical positions. The result was an
apparent major improvement in the randomness of dungeons.

ruins\rules.txt: Changed the dungeon generation rules to precisely match
the complicated scheme we had before. We're still using simple rules to
choose dungeons - I used a program to derive the effective distribution
of dungeon types that the old code would produce and converted it into
the current rule system.
