### PR TITLE
Fix possible NPE in RiftRegenerator.regenerate()

### DIFF
--- a/StevenDimDoors/mod_pocketDim/ticking/RiftRegenerator.java
+++ b/StevenDimDoors/mod_pocketDim/ticking/RiftRegenerator.java
@@ -57,7 +57,10 @@ public class RiftRegenerator implements IRegularTickReceiver {
 							{
 								dimHelper.getWorld(link.locDimID).setBlockTileEntity(link.locXCoord, link.locYCoord, link.locZCoord, new TileEntityRift());
 							}
-							rift.hasGrownRifts = true;
+							if (rift != null)
+							{
+								rift.hasGrownRifts = true;
+							}
 						}
 					}
 				}


### PR DESCRIPTION
After updating to DimDoors 1.5.2R1.4.1RC1-228 (from an older world which was running 1.5.2R1.3.6RC1-67 on 1.5.1), I started getting this log message every 100 ticks:

18:34:42 [SEVERE] An exception occurred in RiftRegenerator.regenerate():
18:34:42 [SEVERE] java.lang.NullPointerException
18:34:42 [SEVERE] at StevenDimDoors.mod_pocketDim.ticking.RiftRegenerator.regenerate(RiftRegenerator.java:60)
18:34:42 [SEVERE] at StevenDimDoors.mod_pocketDim.ticking.RiftRegenerator.notifyTick(RiftRegenerator.java:27)
18:34:42 [SEVERE] at StevenDimDoors.mod_pocketDim.ticking.CommonTickHandler.tickEnd(CommonTickHandler.java:59)
18:34:42 [SEVERE] at cpw.mods.fml.common.SingleIntervalHandler.tickEnd(SingleIntervalHandler.java:34)
18:34:42 [SEVERE] at cpw.mods.fml.common.FMLCommonHandler.tickEnd(FMLCommonHandler.java:141)
18:34:42 [SEVERE] at cpw.mods.fml.common.FMLCommonHandler.onPostServerTick(FMLCommonHandler.java:274)
18:34:42 [SEVERE] at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:763)
18:34:42 [SEVERE] at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:612)
18:34:42 [SEVERE] at net.minecraft.server.ThreadMinecraftServer.run(SourceFile:573)

Not exactly sure what is going on here (corrupted TE?) but adding a null check fixed the log spam, with no apparent ill effect.

(more details at https://gist.github.com/agaricusb/6694659)
