### PR TITLE
Fixed ClassCastException in DungeonPack

### DIFF
--- a/StevenDimDoors/mod_pocketDim/dungeon/pack/DungeonPack.java
+++ b/StevenDimDoors/mod_pocketDim/dungeon/pack/DungeonPack.java
@@ -191,7 +191,14 @@ public class DungeonPack
 							return getRandomDungeon(random, candidates);
 						}
 						//If we've reached this point, then a dungeon was not selected. Discard the type and try again.
-						products.remove(nextType);
+						for (index = 0; index < products.size(); index++)
+						{
+							if (products.get(index).getData().equals(nextType))
+							{
+								products.remove(index);
+								break;
+							}
+						}
 					}
 				}
 				while (nextType != null);


### PR DESCRIPTION
Fixed a bug in DungeonPack that would trigger a rare ClassCastException
during dungeon selection. We were comparing instances of DungeonType
against WeightedContainer<DungeonType>. This wouldn't break dungeon
generation because DD falls back on selecting a random dungeon if
rule-based selection fails. It would allow duplicate dungeons to appear
in the same chain, though.
