### PR TITLE
Commands are guaranteed to be ICommand, not CommandBase.

### DIFF
--- a/src/main/java/StevenDimDoors/mod_pocketDim/commands/DDCommandBase.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/commands/DDCommandBase.java
@@ -1,6 +1,7 @@
 package StevenDimDoors.mod_pocketDim.commands;
 
 import net.minecraft.command.CommandBase;
+import net.minecraft.command.ICommand;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.ChatMessageComponent;
@@ -84,6 +85,6 @@ public abstract class DDCommandBase extends CommandBase
 	@Override
 	public int compareTo(Object par1Obj)
     {
-        return this.getCommandName().compareTo(((CommandBase)par1Obj).getCommandName());
+        return this.getCommandName().compareTo(((ICommand)par1Obj).getCommandName());
     }
 }


### PR DESCRIPTION
Currently some ChickenBones mods add commands that are based on ICommand but not CommandBase.  This causes a crash when a DimDoors command is compared to those commands.  The correct assumption is that all commands are ICommand, not CommandBase.
