### PR TITLE
Fixed Golden Door Item ID Mishandling

### DIFF
--- a/src/main/java/StevenDimDoors/mod_pocketDim/mod_pocketDim.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/mod_pocketDim.java
@@ -206,7 +206,7 @@ public class mod_pocketDim
 		dimensionalDoor = (DimensionalDoor) (new DimensionalDoor(properties.DimensionalDoorID, Material.iron, properties).setHardness(1.0F).setResistance(2000.0F) .setUnlocalizedName("dimDoor"));
 		transTrapdoor = (TransTrapdoor) (new TransTrapdoor(properties.TransTrapdoorID, Material.wood).setHardness(1.0F) .setUnlocalizedName("dimHatch"));
 
-		itemGoldenDoor = (new ItemGoldDoor(properties.GoldenDoorID, Material.wood)).setUnlocalizedName("itemGoldDoor");
+		itemGoldenDoor = (new ItemGoldDoor(properties.GoldenDoorItemID, Material.wood)).setUnlocalizedName("itemGoldDoor");
 		itemGoldenDimensionalDoor = (new ItemGoldDimDoor(properties.GoldenDimensionalDoorItemID, Material.iron, (ItemDoor)this.itemGoldenDoor)).setUnlocalizedName("itemGoldDimDoor");
 		itemDimensionalDoor = (ItemDimensionalDoor) (new ItemDimensionalDoor(properties.DimensionalDoorItemID, Material.iron, (ItemDoor)Item.doorIron)).setUnlocalizedName("itemDimDoor");
 		itemWarpDoor = (new ItemWarpDoor(properties.WarpDoorItemID, Material.wood,(ItemDoor)Item.doorWood)).setUnlocalizedName("itemDimDoorWarp");


### PR DESCRIPTION
PLEASE READ THIS CAREFULLY.

Keybounce noticed that he was having a persistent item ID conflict with DD's Golden Doors - the normal doors not the dimensional variant. I discovered that we have been assigning them the same ID as the Golden Door block ever since they were first introduced 7 months ago. It didn't break immediately since Forge adds +256 to item IDs.

The impact of this is potentially serious but limited. By changing the default ID around, people may lose their Golden Door items unless they change their configs to account for this. This may also cause an item ID conflict to pop up. People have to be told to handle this. Fortunately, it's unlikely people have been stockpiling plain Golden Doors.
