### PR TITLE
Fixed Bugs in Golden Dimensional Doors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'forge'
 
 
 
-version = "2.2.3-" + System.getenv("BUILD_NUMBER")
+version = "2.2.4-" + System.getenv("BUILD_NUMBER")
 group= "com.stevenrs11.dimdoors" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "DimensionalDoors"
 

--- a/src/main/java/StevenDimDoors/mod_pocketDim/EventHookContainer.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/EventHookContainer.java
@@ -30,6 +30,8 @@ import cpw.mods.fml.relauncher.SideOnly;
 
 public class EventHookContainer
 {
+	private static final int MAX_FOOD_LEVEL = 20;
+	
 	private final DDProperties properties;
 
 	public EventHookContainer(DDProperties properties)
@@ -175,6 +177,7 @@ public class EventHookContainer
 		player.extinguish();
 		player.clearActivePotions();
 		player.setHealth(player.getMaxHealth());
+		player.getFoodStats().addStats(MAX_FOOD_LEVEL, 0);
 		Point4D destination = LimboProvider.getLimboSkySpawn(player, properties);
 		DDTeleporter.teleportEntity(player, destination, false);
 	}

--- a/src/main/java/StevenDimDoors/mod_pocketDim/IChunkLoader.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/IChunkLoader.java
@@ -4,5 +4,6 @@ import net.minecraftforge.common.ForgeChunkManager.Ticket;
 
 public interface IChunkLoader 
 {
-	public void forceChunkLoading(Ticket ticket,int x, int z);
+	public boolean isInitialized();
+	public void initialize(Ticket ticket);
 }

--- a/src/main/java/StevenDimDoors/mod_pocketDim/config/DDWorldProperties.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/config/DDWorldProperties.java
@@ -9,7 +9,6 @@ public class DDWorldProperties
 	/**
 	 * World Generation Settings
 	 */
-
 	public final DimensionFilter RiftClusterDimensions;
 	public final DimensionFilter RiftGatewayDimensions;
 	
@@ -17,7 +16,7 @@ public class DDWorldProperties
 	 * General Flags
 	 */
 	public final boolean LimboEscapeEnabled;
-	
+	public final boolean UniversalLimboEnabled;
 	
 	//Names of categories
 	private static final String CATEGORY_WORLD_GENERATION = "world generation";
@@ -43,6 +42,12 @@ public class DDWorldProperties
 				"Sets whether players are teleported out of Limbo when walking over the Eternal Fabric that " + 
 				"generates near the bottom of the dimension. If disabled, players could still leave through " +
 				"dungeons in Limbo or by dying (if Hardcore Limbo is disabled). The default value is true.").getBoolean(true);
+		
+		UniversalLimboEnabled = config.get(Configuration.CATEGORY_GENERAL, "Enable Universal Limbo", false,
+				"Sets whether players are teleported to Limbo when they die in any dimension (except Limbo). " +
+				"Normally, players only go to Limbo if they die in a pocket dimension. This setting will not " + 
+				"affect deaths in Limbo, which can be set with the Hardcore Limbo option. " +
+				"The default value is false.").getBoolean(false);
 		
 		config.save();
 	}

--- a/src/main/java/StevenDimDoors/mod_pocketDim/helpers/ChunkLoaderHelper.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/helpers/ChunkLoaderHelper.java
@@ -1,54 +1,98 @@
 package StevenDimDoors.mod_pocketDim.helpers;
 
-import StevenDimDoors.mod_pocketDim.IChunkLoader;
-import StevenDimDoors.mod_pocketDim.mod_pocketDim;
-import StevenDimDoors.mod_pocketDim.core.NewDimData;
-import StevenDimDoors.mod_pocketDim.core.PocketManager;
-
-import cpw.mods.fml.common.event.FMLServerStartingEvent;
-
 import java.io.File;
 import java.util.List;
 
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.ChunkCoordIntPair;
 import net.minecraft.world.World;
 import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.common.ForgeChunkManager;
 import net.minecraftforge.common.ForgeChunkManager.LoadingCallback;
 import net.minecraftforge.common.ForgeChunkManager.Ticket;
+import net.minecraftforge.common.ForgeChunkManager.Type;
+import StevenDimDoors.experimental.BoundingBox;
+import StevenDimDoors.mod_pocketDim.IChunkLoader;
+import StevenDimDoors.mod_pocketDim.Point3D;
+import StevenDimDoors.mod_pocketDim.mod_pocketDim;
+import StevenDimDoors.mod_pocketDim.core.NewDimData;
+import StevenDimDoors.mod_pocketDim.core.PocketManager;
+import StevenDimDoors.mod_pocketDim.world.PocketBuilder;
+import cpw.mods.fml.common.event.FMLServerStartingEvent;
 
 public class ChunkLoaderHelper implements LoadingCallback 
 {
-
 	@Override
 	public void ticketsLoaded(List<Ticket> tickets, World world) 
 	{
 		for (Ticket ticket : tickets) 
 		{
-			int goldDimDoorX = ticket.getModData().getInteger("goldDimDoorX");
-			int goldDimDoorY = ticket.getModData().getInteger("goldDimDoorY");
-			int goldDimDoorZ = ticket.getModData().getInteger("goldDimDoorZ");
-			if(world.getBlockId(goldDimDoorX, goldDimDoorY, goldDimDoorZ) != mod_pocketDim.properties.GoldenDimensionalDoorID)
+			boolean loaded = false;
+			int x = ticket.getModData().getInteger("goldDimDoorX");
+			int y = ticket.getModData().getInteger("goldDimDoorY");
+			int z = ticket.getModData().getInteger("goldDimDoorZ");
+
+			if (world.getBlockId(x, y, z) == mod_pocketDim.properties.GoldenDimensionalDoorID)
+			{
+				IChunkLoader loader = (IChunkLoader) world.getBlockTileEntity(x, y, z);
+				if (!loader.isInitialized())
+				{
+					loader.initialize(ticket);
+					loaded = true;
+				}
+			}
+			if (!loaded)
 			{
 				ForgeChunkManager.releaseTicket(ticket);
 			}
-			else
+		}
+	}
+
+	public static Ticket createTicket(int x, int y, int z, World world)
+	{
+		NBTTagCompound data;
+		Ticket ticket = ForgeChunkManager.requestTicket(mod_pocketDim.instance, world, Type.NORMAL);
+		if (ticket != null)
+		{
+			data = ticket.getModData();
+			data.setInteger("goldDimDoorX", x);
+			data.setInteger("goldDimDoorY", y);
+			data.setInteger("goldDimDoorZ", z);
+		}
+		return ticket;
+	}
+
+	public static void forcePocketChunks(NewDimData pocket, Ticket ticket)
+	{
+		BoundingBox bounds = PocketBuilder.calculateDefaultBounds(pocket);
+		Point3D minCorner = bounds.minCorner();
+		Point3D maxCorner = bounds.maxCorner();
+		int minX = minCorner.getX() >> 4;
+		int minZ = minCorner.getZ() >> 4;
+		int maxX = maxCorner.getX() >> 4;
+		int maxZ = maxCorner.getZ() >> 4;
+		int chunkX;
+		int chunkZ;
+
+		for (chunkX = minX; chunkX <= maxX; chunkX++)
+		{
+			for (chunkZ = minZ; chunkZ <= maxZ; chunkZ++)
 			{
-				IChunkLoader tile = (IChunkLoader) world.getBlockTileEntity(goldDimDoorX, goldDimDoorY, goldDimDoorZ);
-				tile.forceChunkLoading(ticket,goldDimDoorX,goldDimDoorZ);
-			}			
+				ForgeChunkManager.forceChunk(ticket, new ChunkCoordIntPair(chunkX, chunkZ));
+			}
 		}
 	}
 
 	public static void loadChunkForcedWorlds(FMLServerStartingEvent event)
 	{
-		for(NewDimData data : PocketManager.getDimensions())
+		for (NewDimData data : PocketManager.getDimensions())
 		{
 			if(data.isPocketDimension())
 			{
 				String chunkDir = DimensionManager.getCurrentSaveRootDirectory()+"/DimensionalDoors/pocketDimID" + data.id();
-				
+
 				File file = new File(chunkDir);
-				
+
 				if(file.exists())
 				{
 					if(ForgeChunkManager.savedWorldHasForcedChunkTickets(file))

--- a/src/main/java/StevenDimDoors/mod_pocketDim/mod_pocketDim.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/mod_pocketDim.java
@@ -98,7 +98,7 @@ serverPacketHandlerSpec =
 @SidedPacketHandler(channels = {PacketConstants.CHANNEL_NAME}, packetHandler = ServerPacketHandler.class))
 public class mod_pocketDim
 {
-	public static final String version = "1.6.4-R2.2.3";
+	public static final String version = "1.6.4-R2.2.4";
 	public static final String modid = "dimdoors";
 	
 	//TODO need a place to stick all these constants

--- a/src/main/java/StevenDimDoors/mod_pocketDim/mod_pocketDim.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/mod_pocketDim.java
@@ -63,7 +63,6 @@ import StevenDimDoors.mod_pocketDim.tileentities.TileEntityDimDoor;
 import StevenDimDoors.mod_pocketDim.tileentities.TileEntityDimDoorGold;
 import StevenDimDoors.mod_pocketDim.tileentities.TileEntityRift;
 import StevenDimDoors.mod_pocketDim.tileentities.TileEntityTransTrapdoor;
-import StevenDimDoors.mod_pocketDim.util.DDLogger;
 import StevenDimDoors.mod_pocketDim.world.BiomeGenLimbo;
 import StevenDimDoors.mod_pocketDim.world.BiomeGenPocket;
 import StevenDimDoors.mod_pocketDim.world.DDBiomeGenBase;
@@ -148,6 +147,7 @@ public class mod_pocketDim
 	public static FastRiftRegenerator fastRiftRegenerator;
 	public static GatewayGenerator gatewayGenerator;
 	public static DeathTracker deathTracker;
+	private static EventHookContainer hooks;
 	
 	//TODO this is a temporary workaround for saving data
 	private String currrentSaveRootDirectory;
@@ -177,7 +177,7 @@ public class mod_pocketDim
 		properties = DDProperties.initialize(new File(path));
 
 		//Now do other stuff
-		EventHookContainer hooks = new EventHookContainer(properties);
+		hooks = new EventHookContainer(properties);
 		MinecraftForge.EVENT_BUS.register(hooks);
 		MinecraftForge.TERRAIN_GEN_BUS.register(hooks);
 	}
@@ -336,6 +336,7 @@ public class mod_pocketDim
 		
 		// Load the config file that's specific to this world
 		worldProperties = new DDWorldProperties(new File(currrentSaveRootDirectory + "/DimensionalDoors/DimDoorsWorld.cfg"));
+		hooks.setWorldProperties(worldProperties);
 
 		// Initialize a new DeathTracker
 		deathTracker = new DeathTracker(currrentSaveRootDirectory + "/DimensionalDoors/data/deaths.txt");

--- a/src/main/java/StevenDimDoors/mod_pocketDim/tileentities/TileEntityDimDoorGold.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/tileentities/TileEntityDimDoorGold.java
@@ -1,85 +1,93 @@
 package StevenDimDoors.mod_pocketDim.tileentities;
 
-import net.minecraft.world.ChunkCoordIntPair;
 import net.minecraftforge.common.ForgeChunkManager;
 import net.minecraftforge.common.ForgeChunkManager.Ticket;
-import net.minecraftforge.common.ForgeChunkManager.Type;
 import StevenDimDoors.mod_pocketDim.IChunkLoader;
-import StevenDimDoors.mod_pocketDim.mod_pocketDim;
+import StevenDimDoors.mod_pocketDim.core.NewDimData;
 import StevenDimDoors.mod_pocketDim.core.PocketManager;
-import StevenDimDoors.mod_pocketDim.util.Point4D;
+import StevenDimDoors.mod_pocketDim.helpers.ChunkLoaderHelper;
 import StevenDimDoors.mod_pocketDim.world.PocketBuilder;
 
 public class TileEntityDimDoorGold extends TileEntityDimDoor implements IChunkLoader
 {
 	private Ticket chunkTicket;
+	private boolean initialized = false;
 
 	@Override
 	public boolean canUpdate()
 	{
-		return true;
+		return !initialized;
+	}
+	
+	@Override
+	public boolean isInitialized()
+	{
+		return initialized;
 	}
 
 	@Override
 	public void updateEntity() 
-	{ // every tick?
-		if (PocketManager.getDimensionData(this.worldObj) != null &&
-				PocketManager.getDimensionData(this.worldObj).isPocketDimension() &&
-				!this.worldObj.isRemote)
-		{ 
-			if(PocketManager.getLink(this.xCoord,this.yCoord,this.zCoord,this.worldObj)==null)
+	{
+		if (!initialized)
+		{
+			initialize(null);
+		}
+	}
+	
+	@Override
+	public void initialize(Ticket ticket)
+	{
+		initialized = true;
+		chunkTicket = ticket;
+		
+		// Only do anything if this function is running on the server side
+		// NOTE: We don't have to check whether this block is the upper door
+		// block or the lower one because only one of them should have a
+		// link associated with it.
+		if (!worldObj.isRemote)
+		{
+			NewDimData dimension = PocketManager.getDimensionData(worldObj);
+			
+			// Check whether a ticket has already been assigned to this door
+			if (chunkTicket == null)
 			{
-				return;
-			}
-			if (this.chunkTicket == null)
-			{
-				chunkTicket = ForgeChunkManager.requestTicket(mod_pocketDim.instance, worldObj, Type.NORMAL);
-				if(chunkTicket == null)
+				// No ticket yet.
+				// Check if this area should be loaded and request a new ticket.
+				if (isValidChunkLoaderSetup(dimension))
 				{
-					return;
+					chunkTicket = ChunkLoaderHelper.createTicket(xCoord, yCoord, zCoord, worldObj);
 				}
-				chunkTicket.getModData().setInteger("goldDimDoorX", xCoord);
-				chunkTicket.getModData().setInteger("goldDimDoorY", yCoord);
-				chunkTicket.getModData().setInteger("goldDimDoorZ", zCoord);
-				forceChunkLoading(chunkTicket,this.xCoord,this.zCoord);
+			}
+			else
+			{
+				// A ticket has already been provided.
+				// Check if this area should be loaded. If not, release the ticket.
+				if (!isValidChunkLoaderSetup(dimension))
+				{
+					ForgeChunkManager.releaseTicket(chunkTicket);
+					chunkTicket = null;
+				}
+			}
+			
+			// If chunkTicket isn't null at this point, then this is a valid door setup.
+			// The last step is to request force loading of the pocket's chunks.
+			if (chunkTicket != null)
+			{
+				ChunkLoaderHelper.forcePocketChunks(dimension, chunkTicket);
 			}
 		}
 	}
-
-	@Override
-	public void forceChunkLoading(Ticket chunkTicket,int x,int z)
+	
+	private boolean isValidChunkLoaderSetup(NewDimData dimension)
 	{
-		Point4D origin = PocketManager.getDimensionData(this.worldObj).origin();
-		int orientation = PocketManager.getDimensionData(this.worldObj).orientation();
+		// Check the various conditions that make this a valid door setup.
+		// 1. The door must be inside the pocket's XZ boundaries,
+		//		to prevent loading of chunks with a distant door
+		// 2. The dimension must be a pocket dimension
+		// 3. The door must be linked so that it's clear that it's not a normal door
 		
-		int xOffset=0;
-		int zOffset=0;
-		
-		switch(orientation)
-		{
-		case 0:
-			xOffset = PocketBuilder.DEFAULT_POCKET_SIZE/2;
-			break;
-		case 1: 
-			zOffset = PocketBuilder.DEFAULT_POCKET_SIZE/2;
-
-			break;
-		case 2:
-			xOffset = -PocketBuilder.DEFAULT_POCKET_SIZE/2;
-
-			break;
-		case 3:
-			zOffset = -PocketBuilder.DEFAULT_POCKET_SIZE/2;
-
-			break;
-		}
-		for(int chunkX = -2; chunkX<3;chunkX++)
-		{
-			for(int chunkZ = -2; chunkZ<3;chunkZ++)
-			{
-				ForgeChunkManager.forceChunk(chunkTicket, new ChunkCoordIntPair((origin.getX()+xOffset >> 4)+chunkX, (origin.getZ()+zOffset >> 4)+chunkZ));
-			}
-		}
+		return (dimension.isPocketDimension() && dimension.getLink(xCoord, yCoord, zCoord) != null &&
+				PocketBuilder.calculateDefaultBounds(dimension).contains(xCoord, yCoord, zCoord));
 	}
 
 	@Override

--- a/src/main/java/StevenDimDoors/mod_pocketDim/world/PocketBuilder.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/world/PocketBuilder.java
@@ -8,7 +8,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
 import net.minecraftforge.common.DimensionManager;
-import StevenDimDoors.experimental.MazeBuilder;
+import StevenDimDoors.experimental.BoundingBox;
 import StevenDimDoors.mod_pocketDim.Point3D;
 import StevenDimDoors.mod_pocketDim.blocks.IDimDoor;
 import StevenDimDoors.mod_pocketDim.config.DDProperties;
@@ -21,13 +21,13 @@ import StevenDimDoors.mod_pocketDim.dungeon.DungeonSchematic;
 import StevenDimDoors.mod_pocketDim.dungeon.pack.DungeonPackConfig;
 import StevenDimDoors.mod_pocketDim.helpers.DungeonHelper;
 import StevenDimDoors.mod_pocketDim.helpers.yCoordHelper;
+import StevenDimDoors.mod_pocketDim.items.ItemDimensionalDoor;
 import StevenDimDoors.mod_pocketDim.schematic.BlockRotator;
 import StevenDimDoors.mod_pocketDim.util.Pair;
 import StevenDimDoors.mod_pocketDim.util.Point4D;
-import StevenDimDoors.mod_pocketDim.items.ItemDimensionalDoor;
 
 public class PocketBuilder
-{
+{	
 	public static final int MIN_POCKET_SIZE = 5;
 	public static final int MAX_POCKET_SIZE = 51;
 	public static final int DEFAULT_POCKET_SIZE = 39;
@@ -558,5 +558,40 @@ public class PocketBuilder
 		extBlockStorage.setExtBlockID(localX, y & 15, localZ, blockID);
 		extBlockStorage.setExtBlockMetadata(localX, y & 15, localZ, metadata);
 		chunk.setChunkModified();
+	}
+
+	public static BoundingBox calculateDefaultBounds(NewDimData pocket)
+	{
+		// Calculate the XZ bounds of this pocket assuming that it has the default size
+		// The Y bounds will be set to encompass the height of a chunk.
+		
+		int minX = 0;
+		int minZ = 0;
+		Point4D origin = pocket.origin();
+		int orientation = pocket.orientation();
+		if (orientation < 0 || orientation > 3)
+		{
+			throw new IllegalArgumentException("pocket has an invalid orientation value.");
+		}
+		switch (orientation)
+		{
+		case 0:
+			minX = origin.getX() - DEFAULT_POCKET_WALL_THICKNESS + 1;
+			minZ = origin.getZ() - DEFAULT_POCKET_SIZE / 2;
+			break;
+		case 1:
+			minX = origin.getX() - DEFAULT_POCKET_SIZE / 2;
+			minZ = origin.getZ() - DEFAULT_POCKET_WALL_THICKNESS + 1;
+			break;
+		case 2:
+			minX = origin.getX() + DEFAULT_POCKET_WALL_THICKNESS - DEFAULT_POCKET_SIZE;
+			minZ = origin.getZ() - DEFAULT_POCKET_SIZE / 2;
+			break;
+		case 3:
+			minX = origin.getX() - DEFAULT_POCKET_SIZE / 2;
+			minZ = origin.getZ() + DEFAULT_POCKET_WALL_THICKNESS - DEFAULT_POCKET_SIZE;
+			break;
+		}
+		return new BoundingBox(minX, 0, minZ, DEFAULT_POCKET_SIZE, 255, DEFAULT_POCKET_SIZE);
 	}
 }

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -6,7 +6,7 @@
 "modid": "dimdoors",
 "name": "Dimensional Doors",
 "description": "Bend and twist reality itself, creating pocket dimensions, rifts, and much more",
-"version": "1.6.4-R2.2.3",
+"version": "1.6.4-R2.2.4",
 "credits": "Created by StevenRS11, Coded by StevenRS11 and SenseiKiwi, Logo and Testing by Jaitsu",
 "logoFile": "/dimdoors_logo.png",
 "mcversion": "",


### PR DESCRIPTION
The most important change with this pull request is fixes to bugs in Golden Dimensional Doors. The full details are described in the corresponding commit, but essentially:
1. Fixed the issue with duplicate ticket requests
2. Fixed the selection of pocket boundaries for chunk loading
3. Stopped doors from trying to request tickets constantly if previous requests failed
4. Stopped doors from loading pockets if they are outside the bounds of the pocket

There are also some minor changes:
1. Restore a player's hunger when they respawn in Limbo
2. Added a setting for toggling whether deaths in any dimension (except Limbo) will teleport players to Limbo - known as the Universal Limbo setting
3. Increased our version number
