### PR TITLE
Fixed Eager Dimension Data Creation

### DIFF
--- a/src/main/java/StevenDimDoors/mod_pocketDim/ConnectionHandler.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/ConnectionHandler.java
@@ -1,17 +1,11 @@
 package StevenDimDoors.mod_pocketDim;
 
-import java.io.ByteArrayOutputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.network.INetworkManager;
 import net.minecraft.network.NetLoginHandler;
 import net.minecraft.network.packet.NetHandler;
 import net.minecraft.network.packet.Packet1Login;
 import net.minecraft.network.packet.Packet250CustomPayload;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.integrated.IntegratedServer;
 import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.common.network.ForgePacket;
 import net.minecraftforge.common.network.packet.DimensionRegisterPacket;
@@ -65,7 +59,8 @@ public class ConnectionHandler implements IConnectionHandler
 	@Override
 	public void playerLoggedIn(Player player, NetHandler netHandler, INetworkManager manager)
 	{
-		PocketManager.getDimwatcher().onCreated(new ClientDimData(PocketManager.getDimensionData(0)));
+		// Hax... please don't do this! >_< 
+		PocketManager.getDimwatcher().onCreated(new ClientDimData(PocketManager.createDimensionDataDangerously(0)));
 		
 	}
 }

--- a/src/main/java/StevenDimDoors/mod_pocketDim/EventHookContainer.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/EventHookContainer.java
@@ -236,7 +236,7 @@ public class EventHookContainer
 		Chunk chunk = event.getChunk();
 		if (!chunk.worldObj.isRemote && PocketManager.isLoaded())
 		{
-			NewDimData dimension = PocketManager.getDimensionData(chunk.worldObj);
+			NewDimData dimension = PocketManager.createDimensionData(chunk.worldObj);
 			for (DimLink link : dimension.getChunkLinks(chunk.xPosition, chunk.zPosition))
 			{
 				regenerator.scheduleSlowRegeneration(link);

--- a/src/main/java/StevenDimDoors/mod_pocketDim/blocks/BlockGoldDimDoor.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/blocks/BlockGoldDimDoor.java
@@ -25,7 +25,7 @@ public class BlockGoldDimDoor extends BaseDimDoor
 	{
 		if (!world.isRemote && world.getBlockId(x, y - 1, z) == this.blockID)
 		{
-			NewDimData dimension = PocketManager.getDimensionData(world);
+			NewDimData dimension = PocketManager.createDimensionData(world);
 			DimLink link = dimension.getLink(x, y, z);
 			if (link == null)
 			{

--- a/src/main/java/StevenDimDoors/mod_pocketDim/blocks/DimensionalDoor.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/blocks/DimensionalDoor.java
@@ -22,7 +22,7 @@ public class DimensionalDoor extends BaseDimDoor
 	{
 		if (!world.isRemote && world.getBlockId(x, y - 1, z) == this.blockID)
 		{
-			NewDimData dimension = PocketManager.getDimensionData(world);
+			NewDimData dimension = PocketManager.createDimensionData(world);
 			DimLink link = dimension.getLink(x, y, z);
 			if (link == null)
 			{

--- a/src/main/java/StevenDimDoors/mod_pocketDim/blocks/TransTrapdoor.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/blocks/TransTrapdoor.java
@@ -76,7 +76,7 @@ public class TransTrapdoor extends BlockTrapDoor implements IDimDoor, ITileEntit
 	{
 		if (!world.isRemote)
 		{
-			NewDimData dimension = PocketManager.getDimensionData(world);
+			NewDimData dimension = PocketManager.createDimensionData(world);
 			DimLink link = dimension.getLink(x, y, z);
 			if (link == null && dimension.isPocketDimension())
 			{

--- a/src/main/java/StevenDimDoors/mod_pocketDim/blocks/TransientDoor.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/blocks/TransientDoor.java
@@ -64,7 +64,7 @@ public class TransientDoor extends BaseDimDoor
 	{
 		if (!world.isRemote && world.getBlockId(x, y - 1, z) == this.blockID)
 		{
-			NewDimData dimension = PocketManager.getDimensionData(world);
+			NewDimData dimension = PocketManager.createDimensionData(world);
 			DimLink link = dimension.getLink(x, y, z);
 			if (link == null && dimension.isPocketDimension())
 			{

--- a/src/main/java/StevenDimDoors/mod_pocketDim/blocks/UnstableDoor.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/blocks/UnstableDoor.java
@@ -21,7 +21,7 @@ public class UnstableDoor extends BaseDimDoor
 	{
 		if (!world.isRemote && world.getBlockId(x, y - 1, z) == this.blockID)
 		{
-			NewDimData dimension = PocketManager.getDimensionData(world);
+			NewDimData dimension = PocketManager.createDimensionData(world);
 			dimension.createLink(x, y, z, LinkTypes.RANDOM,world.getBlockMetadata(x, y - 1, z));
 		}
 	}

--- a/src/main/java/StevenDimDoors/mod_pocketDim/blocks/WarpDoor.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/blocks/WarpDoor.java
@@ -22,7 +22,7 @@ public class WarpDoor extends BaseDimDoor
 	{
 		if (!world.isRemote && world.getBlockId(x, y - 1, z) == this.blockID)
 		{
-			NewDimData dimension = PocketManager.getDimensionData(world);
+			NewDimData dimension = PocketManager.createDimensionData(world);
 			DimLink link = dimension.getLink(x, y, z);
 			if (link == null && dimension.isPocketDimension())
 			{

--- a/src/main/java/StevenDimDoors/mod_pocketDim/commands/CommandCreateDungeonRift.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/commands/CommandCreateDungeonRift.java
@@ -61,7 +61,7 @@ public class CommandCreateDungeonRift extends DDCommandBase
 		// Check if we found any matches
 		if (result != null)
 		{
-			dimension = PocketManager.getDimensionData(sender.worldObj);
+			dimension = PocketManager.createDimensionData(sender.worldObj);
 			link = dimension.createLink(x, y + 1, z, LinkTypes.DUNGEON, orientation);
 			if (PocketBuilder.generateSelectedDungeonPocket(link, mod_pocketDim.properties, result))
 			{

--- a/src/main/java/StevenDimDoors/mod_pocketDim/commands/CommandCreateRandomRift.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/commands/CommandCreateRandomRift.java
@@ -53,7 +53,7 @@ public class CommandCreateRandomRift extends DDCommandBase
 
 		if (command.length == 0)
 		{
-			dimension = PocketManager.getDimensionData(sender.worldObj);
+			dimension = PocketManager.createDimensionData(sender.worldObj);
 			link = dimension.createLink(x, y + 1, z, LinkTypes.DUNGEON, orientation);
 			sender.worldObj.setBlock(x, y + 1, z,mod_pocketDim.blockRift.blockID, 0, 3);
 			sendChat(sender, "Created a rift to a random dungeon.");
@@ -69,7 +69,7 @@ public class CommandCreateRandomRift extends DDCommandBase
 			// Check if we found any matches
 			if (result != null)
 			{
-				dimension = PocketManager.getDimensionData(sender.worldObj);
+				dimension = PocketManager.createDimensionData(sender.worldObj);
 				link = dimension.createLink(x, y + 1, z, LinkTypes.DUNGEON, orientation);
 				if (PocketBuilder.generateSelectedDungeonPocket(link, mod_pocketDim.properties, result))
 				{

--- a/src/main/java/StevenDimDoors/mod_pocketDim/commands/CommandDeleteRifts.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/commands/CommandDeleteRifts.java
@@ -63,7 +63,7 @@ public class CommandDeleteRifts extends DDCommandBase
 		int y;
 		int z;
 		Point4D location;
-		NewDimData dimension = PocketManager.getDimensionData(targetDimension);
+		NewDimData dimension = PocketManager.createDimensionData(world);
 		ArrayList<DimLink> links = dimension.getAllLinks();
 		for (DimLink link : links)
 		{

--- a/src/main/java/StevenDimDoors/mod_pocketDim/commands/CommandTeleportPlayer.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/commands/CommandTeleportPlayer.java
@@ -80,7 +80,6 @@ public class CommandTeleportPlayer extends DDCommandBase
 		else
 		{
 			dimensionID = targetPlayer.worldObj.provider.dimensionId;
-			// SenseiKiwi: Will not be used, but I prefer not to leave 'world' as null
 			world = targetPlayer.worldObj;
 		}
 		
@@ -95,7 +94,7 @@ public class CommandTeleportPlayer extends DDCommandBase
 		if (command.length == 2)
 		{
 			// Check if the destination is a pocket dimension
-			dimension = PocketManager.getDimensionData(dimensionID);
+			dimension = PocketManager.createDimensionData(world);
 			if (dimension.isPocketDimension())
 			{
 				// The destination is a pocket dimension.

--- a/src/main/java/StevenDimDoors/mod_pocketDim/core/DDTeleporter.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/core/DDTeleporter.java
@@ -227,7 +227,7 @@ public class DDTeleporter
 			&& blockID != properties.GoldenDimensionalDoorID)
 		{
 			//Return the pocket's orientation instead
-			return PocketManager.getDimensionData(door.getDimension()).orientation();
+			return PocketManager.createDimensionData(world).orientation();
 		}
 		
 		//Return the orientation portion of its metadata
@@ -294,7 +294,7 @@ public class DDTeleporter
 				// to prevent us from doing bad things. Moreover, no dimension is being created, so if we ever
 				// tie code to that, it could cause confusing bugs.
 				// No hacky for you! ~SenseiKiwi
-				PocketManager.getDimwatcher().onCreated(new ClientDimData(PocketManager.getDimensionData(destination.getDimension())));
+				PocketManager.getDimwatcher().onCreated(new ClientDimData(PocketManager.createDimensionData(newWorld)));
 				  
 				// Set the new dimension and inform the client that it's moving to a new world.
 				player.dimension = destination.getDimension();
@@ -552,7 +552,7 @@ public class DDTeleporter
 		// To avoid loops, don't generate a destination if the player is
 		// already in a non-pocket dimension.
 		
-		NewDimData current = PocketManager.getDimensionData(link.link.point.getDimension());
+		NewDimData current = PocketManager.getDimensionData(link.source().getDimension());
 		if (current.isPocketDimension())
 		{
 			Point4D source = link.source();
@@ -606,9 +606,10 @@ public class DDTeleporter
 			}
 		}
 	}
+	
 	private static boolean generateSafeExit(DimLink link, DDProperties properties)
 	{
-		NewDimData current = PocketManager.getDimensionData(link.link.point.getDimension());
+		NewDimData current = PocketManager.getDimensionData(link.source().getDimension());
 		return generateSafeExit(current.root(), link, properties);
 	}
 	
@@ -619,7 +620,7 @@ public class DDTeleporter
 		// There is a chance of choosing the Nether first before other root dimensions
 		// to compensate for servers with many Mystcraft ages or other worlds.
 		
-		NewDimData current = PocketManager.getDimensionData(link.link.point.getDimension());
+		NewDimData current = PocketManager.getDimensionData(link.source().getDimension());
 		ArrayList<NewDimData> roots = PocketManager.getRootDimensions();
 		int shiftChance = START_ROOT_SHIFT_CHANCE + ROOT_SHIFT_CHANCE_PER_LEVEL * (current.packDepth() - 1);
 
@@ -627,11 +628,11 @@ public class DDTeleporter
 		{
 			if (current.root().id() != OVERWORLD_DIMENSION_ID && random.nextInt(MAX_OVERWORLD_EXIT_CHANCE) < OVERWORLD_EXIT_CHANCE)
 			{
-				return generateSafeExit(PocketManager.getDimensionData(OVERWORLD_DIMENSION_ID), link, properties);
+				return generateSafeExit(PocketManager.createDimensionDataDangerously(OVERWORLD_DIMENSION_ID), link, properties);
 			}
 			if (current.root().id() != NETHER_DIMENSION_ID && random.nextInt(MAX_NETHER_EXIT_CHANCE) < NETHER_EXIT_CHANCE)
 			{
-				return generateSafeExit(PocketManager.getDimensionData(NETHER_DIMENSION_ID), link, properties);
+				return generateSafeExit(PocketManager.createDimensionDataDangerously(NETHER_DIMENSION_ID), link, properties);
 			}
 			for (int attempts = 0; attempts < 10; attempts++)
 			{
@@ -735,7 +736,7 @@ public class DDTeleporter
 			// Create a reverse link for returning
 			int orientation = getDestinationOrientation(source, properties);
 			NewDimData sourceDim = PocketManager.getDimensionData(link.source().getDimension());
-			DimLink reverse = destinationDim.createLink(x, y + 2, z, LinkTypes.REVERSE,orientation);
+			DimLink reverse = destinationDim.createLink(x, y + 2, z, LinkTypes.REVERSE, orientation);
 			sourceDim.setLinkDestination(reverse, source.getX(), source.getY(), source.getZ());
 			
 			// Set up the warp door at the destination

--- a/src/main/java/StevenDimDoors/mod_pocketDim/dungeon/DungeonSchematic.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/dungeon/DungeonSchematic.java
@@ -247,7 +247,7 @@ public class DungeonSchematic extends Schematic {
 			world.setBlockTileEntity(pocketPoint.getX(), pocketPoint.getY(), pocketPoint.getZ(), TileEntity.createAndLoadEntity(tileTag));
 		}
 		
-		setUpDungeon(PocketManager.getDimensionData(world), world, pocketCenter, turnAngle, entryLink, random, properties, blockSetter);
+		setUpDungeon(PocketManager.createDimensionData(world), world, pocketCenter, turnAngle, entryLink, random, properties, blockSetter);
 	}
 	
 	private void setUpDungeon(NewDimData dimension, World world, Point3D pocketCenter, int turnAngle, DimLink entryLink, Random random, DDProperties properties, IBlockSetter blockSetter)

--- a/src/main/java/StevenDimDoors/mod_pocketDim/helpers/DungeonHelper.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/helpers/DungeonHelper.java
@@ -263,7 +263,7 @@ public class DungeonHelper
 	public DimLink createCustomDungeonDoor(World world, int x, int y, int z)
 	{
 		//Create a link above the specified position. Link to a new pocket dimension.
-		NewDimData dimension = PocketManager.getDimensionData(world);
+		NewDimData dimension = PocketManager.createDimensionData(world);
 		DimLink link = dimension.createLink(x, y + 1, z, LinkTypes.POCKET, 3);
 		
 		//Place a Warp Door linked to that pocket

--- a/src/main/java/StevenDimDoors/mod_pocketDim/items/ItemRiftSignature.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/items/ItemRiftSignature.java
@@ -74,7 +74,7 @@ public class ItemRiftSignature extends Item
 			// The link was used before and already has an endpoint stored.
 			// Create links connecting the two endpoints.
 			NewDimData sourceDimension = PocketManager.getDimensionData(source.getDimension());
-			NewDimData destinationDimension = PocketManager.getDimensionData(world);
+			NewDimData destinationDimension = PocketManager.createDimensionData(world);
 			DimLink link = sourceDimension.createLink(source.getX(), source.getY(), source.getZ(), LinkTypes.NORMAL,source.getOrientation());
 			DimLink reverse = destinationDimension.createLink(x, adjustedY, z, LinkTypes.NORMAL,orientation);
 			destinationDimension.setLinkDestination(link, x, adjustedY, z);
@@ -99,7 +99,7 @@ public class ItemRiftSignature extends Item
 		else
 		{
 			//The link signature has not been used. Store its current target as the first location. 
-			setSource(stack, x, adjustedY, z,orientation, PocketManager.getDimensionData(world));
+			setSource(stack, x, adjustedY, z, orientation, PocketManager.createDimensionData(world));
 			mod_pocketDim.sendChat(player,("Location Stored in Rift Signature"));
 			world.playSoundAtEntity(player,mod_pocketDim.modid+":riftStart", 0.6f, 1);
 		}

--- a/src/main/java/StevenDimDoors/mod_pocketDim/items/ItemStabilizedRiftSignature.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/items/ItemStabilizedRiftSignature.java
@@ -53,7 +53,7 @@ public class ItemStabilizedRiftSignature extends ItemRiftSignature
 		{
 			// Yes, it's initialized.
 			NewDimData sourceDimension = PocketManager.getDimensionData(source.getDimension());
-			NewDimData destinationDimension = PocketManager.getDimensionData(world);
+			NewDimData destinationDimension = PocketManager.createDimensionData(world);
 			DimLink reverse = destinationDimension.getLink(x, adjustedY, z);
 			DimLink link;
 			
@@ -104,7 +104,7 @@ public class ItemStabilizedRiftSignature extends ItemRiftSignature
 		else
 		{
 			// The link signature has not been used. Store its current target as the first location. 
-			setSource(stack, x, adjustedY, z, orientation, PocketManager.getDimensionData(world));
+			setSource(stack, x, adjustedY, z, orientation, PocketManager.createDimensionData(world));
 			mod_pocketDim.sendChat(player, "Location Stored in Stabilized Rift Signature");
 			world.playSoundAtEntity(player, "mods.DimDoors.sfx.riftStart", 0.6f, 1);
 		}
@@ -129,7 +129,7 @@ public class ItemStabilizedRiftSignature extends ItemRiftSignature
 		if (source != null)
 		{
 			NewDimData sourceDimension = PocketManager.getDimensionData(source.getDimension());
-			NewDimData destinationDimension = PocketManager.getDimensionData(world);
+			NewDimData destinationDimension = PocketManager.createDimensionData(world);
 			DimLink reverse = destinationDimension.getLink(x, adjustedY, z);
 			DimLink link;
 			

--- a/src/main/java/StevenDimDoors/mod_pocketDim/items/itemRiftRemover.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/items/itemRiftRemover.java
@@ -54,7 +54,7 @@ public class itemRiftRemover extends Item
 			int hx = hit.blockX;
 			int hy = hit.blockY;
 			int hz = hit.blockZ;
-			NewDimData dimension = PocketManager.getDimensionData(world);
+			NewDimData dimension = PocketManager.createDimensionData(world);
 			DimLink link = dimension.getLink(hx, hy, hz);
 			if (world.getBlockId(hx, hy, hz) == mod_pocketDim.blockRift.blockID && link != null &&
 				player.canPlayerEdit(hx, hy, hz, hit.sideHit, stack))
@@ -85,7 +85,7 @@ public class itemRiftRemover extends Item
 			 y = hit.blockY;
 			 z = hit.blockZ;
 			 
-			 NewDimData dimension = PocketManager.getDimensionData(world);
+			 NewDimData dimension = PocketManager.createDimensionData(world);
 			 DimLink link = dimension.getLink(x, y, z);
 			 if (world.getBlockId(x, y, z) == mod_pocketDim.blockRift.blockID && link != null &&
 				player.canPlayerEdit(x, y, z, side, stack))

--- a/src/main/java/StevenDimDoors/mod_pocketDim/saving/DDSaveHandler.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/saving/DDSaveHandler.java
@@ -189,7 +189,7 @@ public class DDSaveHandler
 		{
 			if(packedLink.parent.equals(fakePoint))
 			{
-				NewDimData data = PocketManager.getDimensionData(packedLink.source.getDimension());
+				NewDimData data = PocketManager.createDimensionDataDangerously(packedLink.source.getDimension());
 				int linkType = packedLink.tail.linkType;
 				
 				if((linkType < LinkTypes.ENUM_MIN || linkType > LinkTypes.ENUM_MAX) && linkType != LinkTypes.CLIENT_SIDE)
@@ -201,7 +201,7 @@ public class DDSaveHandler
 				Point4D destination = packedLink.tail.destination;
 				if(destination!=null)
 				{
-					PocketManager.getDimensionData(destination.getDimension()).setLinkDestination(link, destination.getX(),destination.getY(),destination.getZ());
+					PocketManager.createDimensionDataDangerously(destination.getDimension()).setLinkDestination(link, destination.getX(),destination.getY(),destination.getZ());
 				}
 				unpackedLinks.add(packedLink);
 			}
@@ -213,7 +213,7 @@ public class DDSaveHandler
 		{
 			for(PackedLinkData packedLink : linksToUnpack)
 			{
-				NewDimData data = PocketManager.getDimensionData(packedLink.source.getDimension());
+				NewDimData data = PocketManager.createDimensionDataDangerously(packedLink.source.getDimension());
 				if(data.getLink(packedLink.parent)!=null)
 				{
 					data.createChildLink(packedLink.source.getX(), packedLink.source.getY(), packedLink.source.getZ(), data.getLink(packedLink.parent));

--- a/src/main/java/StevenDimDoors/mod_pocketDim/tileentities/TileEntityDimDoorGold.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/tileentities/TileEntityDimDoorGold.java
@@ -46,7 +46,7 @@ public class TileEntityDimDoorGold extends TileEntityDimDoor implements IChunkLo
 		// link associated with it.
 		if (!worldObj.isRemote)
 		{
-			NewDimData dimension = PocketManager.getDimensionData(worldObj);
+			NewDimData dimension = PocketManager.createDimensionData(worldObj);
 			
 			// Check whether a ticket has already been assigned to this door
 			if (chunkTicket == null)

--- a/src/main/java/StevenDimDoors/mod_pocketDim/tileentities/TileEntityRift.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/tileentities/TileEntityRift.java
@@ -137,7 +137,7 @@ public class TileEntityRift extends DDTileEntityBase
 
 	private void closeRift()
 	{
-		NewDimData dimension = PocketManager.getDimensionData(worldObj);
+		NewDimData dimension = PocketManager.createDimensionData(worldObj);
 		if (closeTimer == CLOSING_PERIOD / 2)
 		{
 			for (DimLink riftLink : dimension.findRiftsInRange(worldObj, 6, xCoord, yCoord, zCoord))
@@ -167,7 +167,7 @@ public class TileEntityRift extends DDTileEntityBase
 	public boolean updateNearestRift()
 	{
 		Point4D previousNearest = nearestRiftLocation;
-		DimLink nearestRiftLink = PocketManager.getDimensionData(worldObj).findNearestRift(
+		DimLink nearestRiftLink = PocketManager.createDimensionData(worldObj).findNearestRift(
 				worldObj, RIFT_INTERACTION_RANGE, xCoord, yCoord, zCoord);
 		
 		nearestRiftLocation = (nearestRiftLink == null) ? null : nearestRiftLink.source();
@@ -221,7 +221,7 @@ public class TileEntityRift extends DDTileEntityBase
 			return;
 		}
 
-		NewDimData dimension = PocketManager.getDimensionData(worldObj);
+		NewDimData dimension = PocketManager.createDimensionData(worldObj);
 		DimLink link = dimension.getLink(xCoord, yCoord, zCoord);
 		
 		if (link.childCount() >= MAX_CHILD_LINKS || countAncestorLinks(link) >= MAX_ANCESTOR_LINKS)

--- a/src/main/java/StevenDimDoors/mod_pocketDim/world/PocketGenerator.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/world/PocketGenerator.java
@@ -68,7 +68,7 @@ public class PocketGenerator extends ChunkProviderGenerate
 	@Override
 	public List getPossibleCreatures(EnumCreatureType var1, int var2, int var3, int var4) 
 	{
-		NewDimData dimension = PocketManager.getDimensionData(this.worldObj);
+		NewDimData dimension = PocketManager.createDimensionData(this.worldObj);
 		if (dimension != null && dimension.dungeon() != null && !dimension.dungeon().isOpen())
 		{
 			return this.worldObj.getBiomeGenForCoords(var2, var3).getSpawnableList(var1);

--- a/src/main/java/StevenDimDoors/mod_pocketDim/world/PocketProvider.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/world/PocketProvider.java
@@ -7,7 +7,6 @@ import net.minecraft.world.WorldProvider;
 import net.minecraft.world.biome.WorldChunkManagerHell;
 import net.minecraft.world.chunk.IChunkProvider;
 import net.minecraftforge.client.IRenderHandler;
-import net.minecraftforge.common.DimensionManager;
 import StevenDimDoors.mod_pocketDim.CloudRenderBlank;
 import StevenDimDoors.mod_pocketDim.mod_pocketDim;
 import StevenDimDoors.mod_pocketDim.config.DDProperties;
@@ -103,11 +102,8 @@ public class PocketProvider extends WorldProvider
 		{
 			respawnDim = PocketManager.getDimensionData(this.dimensionId).root().id();
 		}
-
-		if (DimensionManager.getWorld(respawnDim) == null)
-		{
-			DimensionManager.initDimension(respawnDim);
-		}
+		// TODO: Are we sure we need to load the dimension as well? Why can't the game handle that?
+		PocketManager.loadDimension(respawnDim);
 		return respawnDim;
 	}
 

--- a/src/main/java/StevenDimDoors/mod_pocketDim/world/fortresses/ComponentNetherGateway.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/world/fortresses/ComponentNetherGateway.java
@@ -154,7 +154,7 @@ public class ComponentNetherGateway extends StructureComponent
         if (bounds.isVecInside(x, y, z) && bounds.isVecInside(x, y + 1, z))
         {
         	orientation = this.getMetadataWithOffset(Block.doorWood.blockID, 1);
-        	dimension = PocketManager.getDimensionData(world);
+        	dimension = PocketManager.createDimensionData(world);
         	link = dimension.getLink(x, y + 1, z);
         	if (link == null)
         	{

--- a/src/main/java/StevenDimDoors/mod_pocketDim/world/gateways/BaseSchematicGateway.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/world/gateways/BaseSchematicGateway.java
@@ -44,7 +44,7 @@ public abstract class BaseSchematicGateway extends BaseGateway
 		this.generateRandomBits(world, x, y, z);
 		
 		// Generate a dungeon link in the door
-		PocketManager.getDimensionData(world).createLink(x, y + doorLocation.getY(), z, LinkTypes.DUNGEON, orientation);
+		PocketManager.createDimensionData(world).createLink(x, y + doorLocation.getY(), z, LinkTypes.DUNGEON, orientation);
 		
 		return true;
 	}

--- a/src/main/java/StevenDimDoors/mod_pocketDim/world/gateways/GatewayGenerator.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/world/gateways/GatewayGenerator.java
@@ -106,7 +106,7 @@ public class GatewayGenerator implements IWorldGenerator
 					//Create a link. If this is not the first time, create a child link and connect it to the first link.
 					if (link == null)
 					{
-						dimension = PocketManager.getDimensionData(world);
+						dimension = PocketManager.createDimensionData(world);
 						link = dimension.createLink(x, y + 1, z, LinkTypes.DUNGEON,0);
 					}
 					else

--- a/src/main/java/StevenDimDoors/mod_pocketDim/world/gateways/GatewayLimbo.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/world/gateways/GatewayLimbo.java
@@ -30,7 +30,7 @@ public class GatewayLimbo extends BaseGateway
 		world.setBlock(x, y + 1, z - 1, blockID, 0, 3);
 		world.setBlock(x, y + 1, z + 1, blockID, 0, 3);
 
-		PocketManager.getDimensionData(world).createLink(x, y + 2, z, LinkTypes.DUNGEON, 0);
+		PocketManager.createDimensionData(world).createLink(x, y + 2, z, LinkTypes.DUNGEON, 0);
 		ItemDoor.placeDoorBlock(world, x, y + 1, z, 0, mod_pocketDim.transientDoor);
 		return true;
 	}

--- a/src/main/java/StevenDimDoors/mod_pocketDimClient/ClosingRiftFX.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDimClient/ClosingRiftFX.java
@@ -100,7 +100,7 @@ public class ClosingRiftFX extends EntityFX
 		 float var15 = (float)(this.prevPosZ + (this.posZ - this.prevPosZ) * par2 - interpPosZ);
 		 float var16 = 0.8F;
 
-		 if (PocketManager.getDimensionData(worldObj).isPocketDimension())
+		 if (PocketManager.createDimensionData(worldObj).isPocketDimension())
 		 {
 			 var16 = 0.4F;
 		 }

--- a/src/main/java/StevenDimDoors/mod_pocketDimClient/GoggleRiftFX.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDimClient/GoggleRiftFX.java
@@ -54,7 +54,7 @@ public class GoggleRiftFX extends EntityFireworkSparkFX
 		float var15 = (float)(this.prevPosZ + (this.posZ - this.prevPosZ) * par2 - interpPosZ);
 		float var16 = .0F;
 
-		if (PocketManager.getDimensionData(worldObj).isPocketDimension())
+		if (PocketManager.createDimensionData(worldObj).isPocketDimension())
 		{
 			var16 = .7F;
 		}

--- a/src/main/java/StevenDimDoors/mod_pocketDimClient/RiftFX.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDimClient/RiftFX.java
@@ -111,7 +111,7 @@ public class RiftFX extends EntityFX
         float f13 = (float)(this.prevPosZ + (this.posZ - this.prevPosZ) * par2 - interpPosZ);
         float f14 = 0F;
         
-        if (PocketManager.getDimensionData(worldObj).isPocketDimension())
+        if (PocketManager.createDimensionData(worldObj).isPocketDimension())
     	{
     		f14 = 0.7F;
     	}


### PR DESCRIPTION
1. Fixed a design flaw in PocketManager. We originally assumed that all
   requests to PocketManager.getDimensionData() had to be legitimate
   requests for dimensions that existed. That was true in most cases, but
   for things like processing user commands, it was dangerously optimistic.
   It was possible that a flaw in DD's usage of that function could be
   exploited by a player to trick the mod into pre-registering dimension
   data for a non-existent dimension. That would declare the dimension as a
   root. DD would crash later if Forge ever allocated that ID for a pocket
   dimension. The new implementation is almost the same as the old one, but
   allows us to differentiate between cases when we can eagerly create
   dimension data, and cases in which the absence of a dimension should
   cause a crash to alert us of a design flaw.
2. Remove the pocket regeneration code from PocketBuilder. We simply
   don't support pocket regeneration and it's unlikely it'll ever be
   implemented because it's a difficult issue. Wiping out pockets
   completely is easier. We can always recover the code from this commit if
   it's needed later.
3. Minor changes: removed some debug prints from PocketManager and
   changed some static accesses in PocketBuilder.
