### PR TITLE
Fixed Crash on Rift Removal

### DIFF
--- a/src/main/java/StevenDimDoors/mod_pocketDim/tileentities/TileEntityRift.java
+++ b/src/main/java/StevenDimDoors/mod_pocketDim/tileentities/TileEntityRift.java
@@ -151,7 +151,7 @@ public class TileEntityRift extends DDTileEntityBase
 				}
 			}
 		}
-		if (closeTimer >= CLOSING_PERIOD)
+		if (closeTimer >= CLOSING_PERIOD && !worldObj.isRemote)
 		{
 			DimLink link = PocketManager.getLink(this.xCoord, this.yCoord, this.zCoord, worldObj);
 			if (link != null)


### PR DESCRIPTION
Fixed a crash from manipulating rift data on the client side. I let this happen because it seemed like TileEntityRift already did that before. This crash also exposed another issue: that server-side functions are being used on the client side. I'm not sure how pervasive this is but some client dimensions are being constructed with the server-side-only constructor.
